### PR TITLE
Implement placement phase for player starting positions

### DIFF
--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -1,6 +1,12 @@
 using System.Collections.Generic;
 using UnityEngine;
 
+public enum GamePhase
+{
+    Placement,
+    Playing
+}
+
 public class GameManager : MonoBehaviour
 {
     public static GameManager Instance;
@@ -8,6 +14,11 @@ public class GameManager : MonoBehaviour
     public int maxRounds = 15;
     public int currentRound = 1;
     public int stepsPerTurn = 1;
+
+    public GamePhase CurrentPhase { get; private set; } = GamePhase.Placement;
+
+    private List<PlayerData> placementOrder = new List<PlayerData>();
+    private int placementIndex = 0;
 
     [Header("Team Configuration")]
     [Tooltip("How many police teams participate in the game")] 
@@ -30,6 +41,7 @@ public class GameManager : MonoBehaviour
     {
         Instance = this;
         InitializeTeams();
+        BeginPlacement();
     }
 
     void InitializeTeams()
@@ -58,7 +70,6 @@ public class GameManager : MonoBehaviour
             AddThief(new PlayerData($"t{i}", PlayerRole.Thief, -1));
         }
 
-        BeginTurn();
     }
 
     void AddPlayer(PlayerData player)
@@ -71,6 +82,38 @@ public class GameManager : MonoBehaviour
     {
         thiefPlayers.Add(thief);
         allPlayers.Add(thief);
+    }
+
+    void BeginPlacement()
+    {
+        CurrentPhase = GamePhase.Placement;
+        placementOrder.Clear();
+        for (int i = 0; i < policeTeamCount; i++)
+        {
+            placementOrder.AddRange(policeTeams[i]);
+        }
+        placementOrder.AddRange(thiefPlayers);
+        placementIndex = 0;
+        PromptPlacement();
+    }
+
+    void PromptPlacement()
+    {
+        if (placementIndex >= placementOrder.Count)
+        {
+            CurrentPhase = GamePhase.Playing;
+            BeginTurn();
+            return;
+        }
+
+        var player = placementOrder[placementIndex];
+        PlayerInputController.Instance.StartPlacement(player);
+    }
+
+    public void ConfirmPlacement()
+    {
+        placementIndex++;
+        PromptPlacement();
     }
 
     void BeginTurn()

--- a/Assets/Scripts/PlayerInputController.cs
+++ b/Assets/Scripts/PlayerInputController.cs
@@ -17,6 +17,8 @@ public class PlayerInputController : MonoBehaviour
     private int selectedNodeId = -1;
     private int originalNodeId = -1;
 
+    private bool placementMode = false;
+
     private ActionType currentAction;
 
     void Awake()
@@ -40,6 +42,15 @@ public class PlayerInputController : MonoBehaviour
         HighlightCurrentNode();
     }
 
+    public void StartPlacement(PlayerData player)
+    {
+        placementMode = true;
+        currentPlayer = player;
+        selectedNodeId = -1;
+        originalNodeId = -1;
+        Debug.Log($"Select start position for {player.playerName}");
+    }
+
     void HighlightCurrentNode()
     {
         foreach (var ui in MapManager.Instance.GetAllNodeUIs())
@@ -51,6 +62,16 @@ public class PlayerInputController : MonoBehaviour
 
     public void OnNodeClicked(int nodeId)
     {
+        if (placementMode)
+        {
+            if (currentPlayer == null) return;
+            currentPlayer.currentNodeId = nodeId;
+            MapManager.Instance.GetNodeUI(nodeId)?.Highlight();
+            placementMode = false;
+            GameManager.Instance.ConfirmPlacement();
+            return;
+        }
+
         if (currentPlayer == null || currentPlayer.remainingSteps <= 0) return;
 
         if (!MapManager.Instance.AreNodesConnected(currentPlayer.currentNodeId, nodeId))


### PR DESCRIPTION
## Summary
- add a `GamePhase` enum
- manage placement of all players before the first round begins
- allow `PlayerInputController` to handle placement clicks

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68473379cb908333aa7ee68e32d3149c