### PR TITLE
Add player tokens to map

### DIFF
--- a/Assets/Scripts/MapManager.cs
+++ b/Assets/Scripts/MapManager.cs
@@ -32,6 +32,10 @@ public class MapManager : MonoBehaviour
     void Start()
     {
         LoadAndBuildMap();
+        if (PlayerTokenManager.Instance != null && GameManager.Instance != null)
+        {
+            PlayerTokenManager.Instance.CreateTokens(GameManager.Instance.GetAllPlayers());
+        }
     }
 
     public void LoadAndBuildMap()

--- a/Assets/Scripts/PlayerInputController.cs
+++ b/Assets/Scripts/PlayerInputController.cs
@@ -66,6 +66,8 @@ public class PlayerInputController : MonoBehaviour
         {
             if (currentPlayer == null) return;
             currentPlayer.currentNodeId = nodeId;
+            if (PlayerTokenManager.Instance != null)
+                PlayerTokenManager.Instance.UpdateTokenPosition(currentPlayer);
             MapManager.Instance.GetNodeUI(nodeId)?.Highlight();
             placementMode = false;
             GameManager.Instance.ConfirmPlacement();
@@ -109,6 +111,8 @@ public class PlayerInputController : MonoBehaviour
         if (selectedNodeId == -1 || currentPlayer == null) return;
 
         currentPlayer.currentNodeId = selectedNodeId;
+        if (PlayerTokenManager.Instance != null)
+            PlayerTokenManager.Instance.UpdateTokenPosition(currentPlayer);
         currentPlayer.remainingSteps--;
 
         string result = string.Empty;

--- a/Assets/Scripts/PlayerTokenManager.cs
+++ b/Assets/Scripts/PlayerTokenManager.cs
@@ -1,0 +1,52 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+public class PlayerTokenManager : MonoBehaviour
+{
+    public static PlayerTokenManager Instance;
+
+    public GameObject tokenPrefab;
+    public Transform tokenParent;
+
+    private Dictionary<PlayerData, GameObject> tokens = new Dictionary<PlayerData, GameObject>();
+
+    void Awake()
+    {
+        if (Instance == null)
+            Instance = this;
+        else
+            Destroy(gameObject);
+    }
+
+    public void CreateTokens(IEnumerable<PlayerData> players)
+    {
+        foreach (var p in players)
+            CreateToken(p);
+    }
+
+    public void CreateToken(PlayerData player)
+    {
+        if (tokenPrefab == null || tokens.ContainsKey(player))
+            return;
+
+        GameObject token = Instantiate(tokenPrefab, tokenParent);
+        tokens[player] = token;
+        UpdateTokenPosition(player);
+    }
+
+    public void UpdateTokenPosition(PlayerData player)
+    {
+        if (!tokens.TryGetValue(player, out GameObject token))
+            return;
+
+        if (player.currentNodeId < 0)
+            return;
+
+        GameObject nodeObj = MapManager.Instance.GetNodeObject(player.currentNodeId);
+        if (nodeObj == null) return;
+
+        RectTransform tokenRect = token.GetComponent<RectTransform>();
+        tokenRect.SetParent(nodeObj.transform, false);
+        tokenRect.anchoredPosition = Vector2.zero;
+    }
+}


### PR DESCRIPTION
## Summary
- spawn token objects for each player using new `PlayerTokenManager`
- show player token at selected node during placement and actions
- create tokens when map initializes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847bde92ccc83338eadd18b142d437c