### PR TITLE
Link tokens to players and use world-space positioning

### DIFF
--- a/Assets/Scripts/PlayerToken.cs
+++ b/Assets/Scripts/PlayerToken.cs
@@ -1,0 +1,6 @@
+using UnityEngine;
+
+public class PlayerToken : MonoBehaviour
+{
+    public PlayerData player;
+}

--- a/Assets/Scripts/PlayerToken.cs.meta
+++ b/Assets/Scripts/PlayerToken.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c48cdebfc5c64aacb5a274fc854b8ccf
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/PlayerTokenManager.cs
+++ b/Assets/Scripts/PlayerTokenManager.cs
@@ -31,6 +31,10 @@ public class PlayerTokenManager : MonoBehaviour
 
         GameObject token = Instantiate(tokenPrefab, tokenParent);
         tokens[player] = token;
+        var tokenComponent = token.GetComponent<PlayerToken>();
+        if (tokenComponent == null)
+            tokenComponent = token.AddComponent<PlayerToken>();
+        tokenComponent.player = player;
         UpdateTokenPosition(player);
     }
 
@@ -46,7 +50,11 @@ public class PlayerTokenManager : MonoBehaviour
         if (nodeObj == null) return;
 
         RectTransform tokenRect = token.GetComponent<RectTransform>();
-        tokenRect.SetParent(nodeObj.transform, false);
-        tokenRect.anchoredPosition = Vector2.zero;
+        RectTransform nodeRect = nodeObj.GetComponent<RectTransform>();
+        if (nodeRect != null)
+        {
+            tokenRect.SetParent(tokenParent, false);
+            tokenRect.position = nodeRect.position;
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add `PlayerToken` component to hold a reference back to the owning `PlayerData`
- update `PlayerTokenManager` to attach the component when creating tokens
- update token movement to set world position rather than reparenting

## Testing
- `true`


------
https://chatgpt.com/codex/tasks/task_e_6847d13b584883338f7c074337257902