### PR TITLE
Add debug logs for player turns

### DIFF
--- a/Assets/Scripts/PlayerInputController.cs
+++ b/Assets/Scripts/PlayerInputController.cs
@@ -40,6 +40,8 @@ public class PlayerInputController : MonoBehaviour
         originalNodeId = player.currentNodeId;
         selectedNodeId = -1;
         HighlightCurrentNode();
+        int round = GameManager.Instance != null ? GameManager.Instance.CurrentRound : -1;
+        Debug.Log($"[Turn] Round {round} - {currentPlayer.playerName} ({currentPlayer.role}) begins with {currentPlayer.remainingSteps} steps");
     }
 
     public void StartPlacement(PlayerData player)
@@ -114,6 +116,8 @@ public class PlayerInputController : MonoBehaviour
         if (PlayerTokenManager.Instance != null)
             PlayerTokenManager.Instance.UpdateTokenPosition(currentPlayer);
         currentPlayer.remainingSteps--;
+        int round = GameManager.Instance != null ? GameManager.Instance.CurrentRound : -1;
+        Debug.Log($"[Action] Round {round} - {currentPlayer.playerName} performed {currentAction} on node {selectedNodeId}. Remaining steps: {currentPlayer.remainingSteps}");
 
         string result = string.Empty;
         bool isShared = true;


### PR DESCRIPTION
## Summary
- log current round and player when a turn begins
- log player action and remaining steps after each move

## Testing
- `echo "No tests found" && true`


------
https://chatgpt.com/codex/tasks/task_e_6847ddbb1e608333be76f8d041420b69