### PR TITLE
Randomize treasure location

### DIFF
--- a/Assets/Scripts/MapManager.cs
+++ b/Assets/Scripts/MapManager.cs
@@ -1,4 +1,6 @@
 using System.Collections.Generic;
+using System.Linq;
+using System.IO;
 using UnityEngine;
 using UnityEngine.UI;
 
@@ -7,6 +9,19 @@ using UnityEngine.UI;
 public class MapData
 {
     public List<MapNodeData> nodes;
+}
+
+[System.Serializable]
+public class TreasureRecord
+{
+    public int nodeId;
+    public bool collected;
+}
+
+[System.Serializable]
+public class TreasureLog
+{
+    public List<TreasureRecord> treasures = new List<TreasureRecord>();
 }
 
 public class MapManager : MonoBehaviour
@@ -18,6 +33,12 @@ public class MapManager : MonoBehaviour
     public Transform nodeParent;
     public Transform pieceUIParent;
     public GameObject pieceUIPrefab;
+
+    [Header("Treasure Settings")]
+    [Tooltip("Number of treasures placed in each game")] public int treasureCount = 20;
+
+    private TreasureLog treasureLog = new TreasureLog();
+    private string treasureLogPath;
 
     private Dictionary<int, MapNodeData> nodeDataDict = new Dictionary<int, MapNodeData>();
     private Dictionary<int, GameObject> nodeGameObjects = new Dictionary<int, GameObject>();
@@ -34,6 +55,7 @@ public class MapManager : MonoBehaviour
 
     void Start()
     {
+        treasureLogPath = Path.Combine(Application.persistentDataPath, "treasure_log.json");
         LoadAndBuildMap();
         if (PlayerTokenManager.Instance != null && GameManager.Instance != null)
         {
@@ -57,6 +79,73 @@ public class MapManager : MonoBehaviour
             for (int i = 0; i < node.neighbors.Count; i++)
                 node.neighbors[i] += 1;
         }
+
+        // Place treasures so that they are at least two nodes apart
+        int treasureTotal = Mathf.Min(treasureCount, mapData.nodes.Count);
+        foreach (var node in mapData.nodes)
+            node.hasTreasure = false;
+
+        var tempDict = mapData.nodes.ToDictionary(n => n.id);
+        var available = new List<MapNodeData>(mapData.nodes);
+        var chosen = new List<MapNodeData>();
+
+        void RemoveNearby(MapNodeData center)
+        {
+            var remove = new List<MapNodeData>();
+            foreach (var cand in available)
+            {
+                if (GetGraphDistance(tempDict, center.id, cand.id) <= 2)
+                    remove.Add(cand);
+            }
+            foreach (var r in remove)
+                available.Remove(r);
+        }
+
+        if (treasureTotal > 0 && available.Count > 0)
+        {
+            int idx = Random.Range(0, available.Count);
+            var first = available[idx];
+            first.hasTreasure = true;
+            chosen.Add(first);
+            available.RemoveAt(idx);
+            RemoveNearby(first);
+        }
+
+        while (chosen.Count < treasureTotal && available.Count > 0)
+        {
+            MapNodeData best = null;
+            int bestDist = -1;
+            foreach (var cand in available)
+            {
+                int minDist = int.MaxValue;
+                foreach (var c in chosen)
+                {
+                    int d = GetGraphDistance(tempDict, cand.id, c.id);
+                    if (d < minDist) minDist = d;
+                }
+                if (minDist > bestDist)
+                {
+                    bestDist = minDist;
+                    best = cand;
+                }
+            }
+
+            if (best == null || bestDist <= 2)
+                break;
+
+            best.hasTreasure = true;
+            chosen.Add(best);
+            available.Remove(best);
+            RemoveNearby(best);
+        }
+
+        treasureLog.treasures.Clear();
+        foreach (var node in mapData.nodes)
+        {
+            if (node.hasTreasure)
+                treasureLog.treasures.Add(new TreasureRecord { nodeId = node.id, collected = false });
+        }
+        File.WriteAllText(treasureLogPath, JsonUtility.ToJson(treasureLog, true));
         nodeDataDict.Clear();
         nodeGameObjects.Clear();
         nodeUIs.Clear();
@@ -137,6 +226,26 @@ public class MapManager : MonoBehaviour
         treasures.Add(nodeId);
     }
 
+    public bool CollectTreasure(int nodeId)
+    {
+        if (!treasures.Remove(nodeId))
+            return false;
+
+        if (treasurePieces.ContainsKey(nodeId))
+        {
+            Destroy(treasurePieces[nodeId]);
+            treasurePieces.Remove(nodeId);
+        }
+
+        var record = treasureLog.treasures.Find(t => t.nodeId == nodeId);
+        if (record != null)
+        {
+            record.collected = true;
+            File.WriteAllText(treasureLogPath, JsonUtility.ToJson(treasureLog, true));
+        }
+        return true;
+    }
+
     public bool HasTreasure(int nodeId)
     {
         return treasures.Contains(nodeId);
@@ -151,6 +260,25 @@ public class MapManager : MonoBehaviour
     public bool HasFootprint(int nodeId)
     {
         return footprints.ContainsKey(nodeId) && footprints[nodeId].Count > 0;
+    }
+
+    private int GetGraphDistance(Dictionary<int, MapNodeData> dict, int startId, int endId)
+    {
+        if (startId == endId) return 0;
+        var visited = new HashSet<int> { startId };
+        var q = new Queue<(int id, int dist)>();
+        q.Enqueue((startId, 0));
+        while (q.Count > 0)
+        {
+            var (id, dist) = q.Dequeue();
+            foreach (var n in dict[id].neighbors)
+            {
+                if (!visited.Add(n)) continue;
+                if (n == endId) return dist + 1;
+                q.Enqueue((n, dist + 1));
+            }
+        }
+        return int.MaxValue;
     }
 
     void OnDrawGizmos()

--- a/Assets/Scripts/PlayerInputController.cs
+++ b/Assets/Scripts/PlayerInputController.cs
@@ -155,7 +155,15 @@ public class PlayerInputController : MonoBehaviour
         if (currentAction == ActionType.Move && currentPlayer.role == PlayerRole.Thief)
         {
             MapManager.Instance.AddFootprint(selectedNodeId, currentPlayer.playerName);
-            result = MapManager.Instance.HasTreasure(selectedNodeId) ? "Found treasure" : "No treasure";
+            if (MapManager.Instance.HasTreasure(selectedNodeId))
+            {
+                MapManager.Instance.CollectTreasure(selectedNodeId);
+                result = "Found treasure";
+            }
+            else
+            {
+                result = "No treasure";
+            }
         }
         else if (currentAction == ActionType.Investigate && currentPlayer.role != PlayerRole.Thief)
         {


### PR DESCRIPTION
## Summary
- configure number of treasures to place on the map
- create and update a treasure log on map initialization
- mark treasure as collected when thieves move to its location
- ensure treasures spawn at least two nodes apart using a farthest-first algorithm

## Testing
- `pytest -q`
- `npm test` *(fails: missing package.json)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68665ec60ca08333b0e592f40bc9fc71