### PR TITLE
Add game over logic

### DIFF
--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -897,13 +897,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: e4e718170180b47448fc09cb5bff945b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  maxRounds: 15
+  maxRounds: 12
   currentRound: 1
   stepsPerTurn: 2
   policeTeamCount: 3
   regularPoliceCount: 8
   corruptPoliceCount: 2
   thiefCount: 2
+  treasureGoal: 3
 --- !u!4 &434212902
 Transform:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -7,13 +7,27 @@ public enum GamePhase
     Playing
 }
 
+public enum GameResult
+{
+    None,
+    Police,
+    Thieves
+}
+
 public class GameManager : MonoBehaviour
 {
     public static GameManager Instance;
 
-    public int maxRounds = 15;
+    public int maxRounds = 12;
     public int currentRound = 1;
     public int stepsPerTurn = 1;
+
+    [Header("Win Conditions")]
+    [Tooltip("How many treasures thieves must collect to win")]
+    public int treasureGoal = 3;
+
+    private int treasuresCollected = 0;
+    public GameResult Result { get; private set; } = GameResult.None;
 
     public GamePhase CurrentPhase { get; private set; } = GamePhase.Placement;
 
@@ -32,6 +46,7 @@ public class GameManager : MonoBehaviour
     private int currentPlayerIndex = 0;
     private bool thiefPhase = true;
     private int currentThiefIndex = 0;
+    private bool gameOver = false;
 
     private List<List<PlayerData>> policeTeams = new List<List<PlayerData>>();
     private List<PlayerData> thiefPlayers = new List<PlayerData>();
@@ -149,6 +164,8 @@ public class GameManager : MonoBehaviour
 
     public void NextPlayerTurn()
     {
+        if (gameOver)
+            return;
         if (thiefPhase)
         {
             while (currentThiefIndex < thiefPlayers.Count && thiefPlayers[currentThiefIndex].isArrested)
@@ -205,12 +222,9 @@ public class GameManager : MonoBehaviour
         Debug.Log($"Round {currentRound} end");
 
         currentRound++;
-        if (currentRound > maxRounds)
-        {
-            Debug.Log("Game over");
-            return;
-        }
-        BeginTurn();
+        CheckGameEnd();
+        if (!gameOver)
+            BeginTurn();
     }
 
     public bool IsThiefAt(int nodeId)
@@ -243,6 +257,14 @@ public class GameManager : MonoBehaviour
 
         if (PlayerTokenManager.Instance != null)
             PlayerTokenManager.Instance.HideToken(thief);
+
+        CheckGameEnd();
+    }
+
+    public void RecordTreasure()
+    {
+        treasuresCollected++;
+        CheckGameEnd();
     }
 
     public List<PlayerData> GetAllPlayers() => allPlayers;
@@ -263,6 +285,36 @@ public class GameManager : MonoBehaviour
             thiefPlayers.Add(player);
         if (!allPlayers.Contains(player))
             allPlayers.Add(player);
+    }
+
+    bool AreAllThievesArrested()
+    {
+        foreach (var t in thiefPlayers)
+            if (!t.isArrested)
+                return false;
+        return true;
+    }
+
+    void CheckGameEnd()
+    {
+        if (gameOver)
+            return;
+        if (AreAllThievesArrested() || currentRound > maxRounds)
+        {
+            Result = GameResult.Police;
+            GameOver();
+        }
+        else if (treasuresCollected >= treasureGoal)
+        {
+            Result = GameResult.Thieves;
+            GameOver();
+        }
+    }
+
+    void GameOver()
+    {
+        gameOver = true;
+        Debug.Log($"Game over - {Result} win");
     }
 
 }

--- a/Assets/Scripts/PlayerInputController.cs
+++ b/Assets/Scripts/PlayerInputController.cs
@@ -155,10 +155,12 @@ public class PlayerInputController : MonoBehaviour
         if (currentAction == ActionType.Move && currentPlayer.role == PlayerRole.Thief)
         {
             MapManager.Instance.AddFootprint(selectedNodeId, currentPlayer.playerName);
-            if (MapManager.Instance.HasTreasure(selectedNodeId))
+            bool collected = MapManager.Instance.CollectTreasure(selectedNodeId);
+            if (collected)
             {
-                MapManager.Instance.CollectTreasure(selectedNodeId);
                 result = "Found treasure";
+                if (GameManager.Instance != null)
+                    GameManager.Instance.RecordTreasure();
             }
             else
             {


### PR DESCRIPTION
## Summary
- end the game when all thieves are arrested or max rounds reached
- set default round limit to 12 in GameManager and SampleScene
- add treasure goal win condition and record winning side

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686b920161d083338bf4ab16c39d0865