### PR TITLE
Switch map data to 1‑based IDs

### DIFF
--- a/Assets/Resources/Map/test_map.json
+++ b/Assets/Resources/Map/test_map.json
@@ -1,20 +1,20 @@
 {
   "nodes": [
-    { "id": 0, "x": 284.0,  "y": 360.0, "neighbors": [1],       "hasTreasure": false },
-    { "id": 1, "x": 200.0,  "y": 360.0, "neighbors": [0, 2],    "hasTreasure": false },
-    { "id": 2, "x": 120.0,  "y": 360.0, "neighbors": [1, 3],    "hasTreasure": true },
-    { "id": 3, "x":  33.0,  "y": 360.0, "neighbors": [2, 4],    "hasTreasure": false },
-    { "id": 4, "x": -94.0,  "y": 360.0, "neighbors": [3, 5],    "hasTreasure": false },
-    { "id": 5, "x": -124.5, "y": 293.0, "neighbors": [4, 6],    "hasTreasure": false },
-    { "id": 6, "x": -155.0, "y": 229.0, "neighbors": [5, 7],    "hasTreasure": true },
-    { "id": 7, "x": -183.9, "y": 164.0, "neighbors": [6, 8],       "hasTreasure": false },
-    { "id": 8, "x": -221.0, "y": 100.0, "neighbors": [7, 9],       "hasTreasure": false },
-    { "id": 9, "x": -272.0, "y": -33.0, "neighbors": [8, 10],       "hasTreasure": false },
-    { "id": 10, "x": -299.0, "y": -93.0, "neighbors": [9, 11],       "hasTreasure": false },
-    { "id": 11, "x": -354.9, "y": -152.0, "neighbors": [10, 12],       "hasTreasure": true },
-    { "id": 12, "x": -414.9, "y": -152.0, "neighbors": [11, 13],       "hasTreasure": false },
-    { "id": 13, "x": -470.9, "y": -152.0, "neighbors": [12, 14],       "hasTreasure": false },
-    { "id": 14, "x": -558.5, "y": -152.0, "neighbors": [13, 15],       "hasTreasure": false },
-    { "id": 15, "x": -627.4, "y": -69.0, "neighbors": [14],       "hasTreasure": false }
+    { "id": 1,  "x": 284.0,  "y": 360.0, "neighbors": [2],        "hasTreasure": false },
+    { "id": 2,  "x": 200.0,  "y": 360.0, "neighbors": [1, 3],     "hasTreasure": false },
+    { "id": 3,  "x": 120.0,  "y": 360.0, "neighbors": [2, 4],     "hasTreasure": true },
+    { "id": 4,  "x":  33.0,  "y": 360.0, "neighbors": [3, 5],     "hasTreasure": false },
+    { "id": 5,  "x": -94.0,  "y": 360.0, "neighbors": [4, 6],     "hasTreasure": false },
+    { "id": 6,  "x": -124.5, "y": 293.0, "neighbors": [5, 7],    "hasTreasure": false },
+    { "id": 7,  "x": -155.0, "y": 229.0, "neighbors": [6, 8],    "hasTreasure": true },
+    { "id": 8,  "x": -183.9, "y": 164.0, "neighbors": [7, 9],    "hasTreasure": false },
+    { "id": 9,  "x": -221.0, "y": 100.0, "neighbors": [8, 10],   "hasTreasure": false },
+    { "id": 10, "x": -272.0, "y": -33.0, "neighbors": [9, 11],   "hasTreasure": false },
+    { "id": 11, "x": -299.0, "y": -93.0, "neighbors": [10, 12],  "hasTreasure": false },
+    { "id": 12, "x": -354.9, "y": -152.0, "neighbors": [11, 13], "hasTreasure": true },
+    { "id": 13, "x": -414.9, "y": -152.0, "neighbors": [12, 14], "hasTreasure": false },
+    { "id": 14, "x": -470.9, "y": -152.0, "neighbors": [13, 15], "hasTreasure": false },
+    { "id": 15, "x": -558.5, "y": -152.0, "neighbors": [14, 16], "hasTreasure": false },
+    { "id": 16, "x": -627.4, "y": -69.0,  "neighbors": [15],    "hasTreasure": false }
   ]
 }

--- a/Assets/Scripts/MapManager.cs
+++ b/Assets/Scripts/MapManager.cs
@@ -78,13 +78,6 @@ public class MapManager : MonoBehaviour
         }
 
         MapData mapData = JsonUtility.FromJson<MapData>(mapJsonFile.text);
-        // shift IDs so numbering starts at 1
-        foreach (var node in mapData.nodes)
-        {
-            node.id += 1;
-            for (int i = 0; i < node.neighbors.Count; i++)
-                node.neighbors[i] += 1;
-        }
 
         // Place treasures so that they are at least two nodes apart
         int treasureTotal = Mathf.Min(treasureCount, mapData.nodes.Count);


### PR DESCRIPTION
## Summary
- stop adding 1 to node IDs when loading maps
- update example map to use IDs starting at 1

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_687a0129716483338aaef63575de506d