### PR TITLE
Fix intersection line colors in MapDrawer

### DIFF
--- a/Assets/Scripts/MapDrawer.cs
+++ b/Assets/Scripts/MapDrawer.cs
@@ -29,7 +29,15 @@ public class MapDrawer : MonoBehaviour
 
     public RouteColorConfig routeColorConfig;
 
-    private readonly Dictionary<string, UILine> routeLines = new();
+    private class ConnectionInfo
+    {
+        public int fromId;
+        public int toId;
+        public string route;
+        public UILine line;
+    }
+
+    private readonly List<ConnectionInfo> connectionLines = new();
 
     private bool isDrawing = false;
     private bool isEditing = false;
@@ -280,82 +288,81 @@ public class MapDrawer : MonoBehaviour
 
     private void ClearLines()
     {
-        foreach (var pair in routeLines)
+        foreach (var info in connectionLines)
         {
-            if (pair.Value != null)
-                Destroy(pair.Value.gameObject);
+            if (info.line != null)
+                Destroy(info.line.gameObject);
         }
-        routeLines.Clear();
+        connectionLines.Clear();
     }
 
     private void DrawConnections()
     {
         if (mapManager == null) return;
 
-        // Group nodes by route
-        var groups = new Dictionary<string, List<MapNodeData>>();
+        foreach (var info in connectionLines)
+        {
+            if (info.line != null)
+                Destroy(info.line.gameObject);
+        }
+        connectionLines.Clear();
+
         foreach (var node in nodes)
         {
-            if (!groups.TryGetValue(node.route, out var list))
+            foreach (var neighborId in node.neighbors)
             {
-                list = new List<MapNodeData>();
-                groups[node.route] = list;
-            }
-            list.Add(node);
-        }
+                MapNodeData neighbor = nodes.Find(n => n.id == neighborId);
+                if (neighbor == null) continue;
 
-        // Remove lines for routes that no longer exist or have too few nodes
-        var toRemove = new List<string>();
-        foreach (var pair in routeLines)
-        {
-            if (!groups.ContainsKey(pair.Key) || groups[pair.Key].Count < 2)
-            {
-                if (pair.Value != null)
-                    Destroy(pair.Value.gameObject);
-                toRemove.Add(pair.Key);
-            }
-        }
-        foreach (var key in toRemove)
-            routeLines.Remove(key);
-
-        // Create or update lines for each route
-        foreach (var kvp in groups)
-        {
-            string route = kvp.Key;
-            var list = kvp.Value;
-            list.Sort((a, b) => a.id.CompareTo(b.id));
-            if (list.Count < 2)
-                continue;
-
-            if (!routeLines.TryGetValue(route, out var line) || line == null)
-            {
-                Transform parent = mapManager.nodeParent != null ? mapManager.nodeParent : mapRoot;
-                line = UILine.CreateLine(parent);
-                line.transform.SetAsFirstSibling();
-                routeLines[route] = line;
-            }
-
-            while (line.line.Count > list.Count)
-                line.line.Pop();
-            while (line.line.Count < list.Count)
-                line.line.Push();
-
-            for (int i = 0; i < list.Count; i++)
-            {
-                GameObject go = mapManager.GetNodeObject(list[i].id);
-                if (go != null)
+                if (node.route == neighbor.route)
                 {
-                    Vector3 pos = go.GetComponent<RectTransform>().position;
-                    line.line.EditPoint(i, pos, lineWidth);
+                    if (node.id < neighbor.id)
+                        CreateConnection(node.id, neighbor.id, node.route);
+                }
+                else
+                {
+                    if (node.id < neighbor.id)
+                    {
+                        CreateConnection(node.id, neighbor.id, node.route);
+                        CreateConnection(node.id, neighbor.id, neighbor.route);
+                    }
                 }
             }
+        }
+    }
 
-            Color c = GetColorForRoute(route);
-            var grad = new Gradient();
-            grad.SetKeys(
-                new[] { new GradientColorKey(c, 0f), new GradientColorKey(c, 1f) },
-                new[] { new GradientAlphaKey(c.a, 0f), new GradientAlphaKey(c.a, 1f) });
-            line.line.option.color = grad;
+    private void CreateConnection(int fromId, int toId, string route)
+    {
+        Transform parent = mapManager.nodeParent != null ? mapManager.nodeParent : mapRoot;
+        UILine line = UILine.CreateLine(parent);
+        line.transform.SetAsFirstSibling();
+
+        Color c = GetColorForRoute(route);
+        var grad = new Gradient();
+        grad.SetKeys(
+            new[] { new GradientColorKey(c, 0f), new GradientColorKey(c, 1f) },
+            new[] { new GradientAlphaKey(c.a, 0f), new GradientAlphaKey(c.a, 1f) });
+        line.line.option.color = grad;
+
+        var info = new ConnectionInfo
+        {
+            fromId = fromId,
+            toId = toId,
+            route = route,
+            line = line
+        };
+        connectionLines.Add(info);
+
+        GameObject fromObj = mapManager.GetNodeObject(fromId);
+        GameObject toObj = mapManager.GetNodeObject(toId);
+        if (fromObj != null && toObj != null)
+        {
+            while (line.line.Count < 2)
+                line.line.Push();
+            Vector3 fromPos = fromObj.GetComponent<RectTransform>().position;
+            Vector3 toPos = toObj.GetComponent<RectTransform>().position;
+            line.line.EditPoint(0, fromPos, lineWidth);
+            line.line.EditPoint(1, toPos, lineWidth);
         }
     }
 
@@ -363,29 +370,23 @@ public class MapDrawer : MonoBehaviour
     {
         if (mapManager == null) return;
 
-        foreach (var pair in routeLines)
+        foreach (var info in connectionLines)
         {
-            string route = pair.Key;
-            UILine line = pair.Value;
-            if (line == null) continue;
+            if (info.line == null) continue;
 
-            var list = nodes.FindAll(n => n.route == route);
-            list.Sort((a, b) => a.id.CompareTo(b.id));
+            GameObject fromObj = mapManager.GetNodeObject(info.fromId);
+            GameObject toObj = mapManager.GetNodeObject(info.toId);
+            if (fromObj == null || toObj == null) continue;
 
-            while (line.line.Count > list.Count)
-                line.line.Pop();
-            while (line.line.Count < list.Count)
-                line.line.Push();
+            while (info.line.line.Count > 2)
+                info.line.line.Pop();
+            while (info.line.line.Count < 2)
+                info.line.line.Push();
 
-            for (int i = 0; i < list.Count; i++)
-            {
-                GameObject go = mapManager.GetNodeObject(list[i].id);
-                if (go != null)
-                {
-                    Vector3 pos = go.GetComponent<RectTransform>().position;
-                    line.line.EditPoint(i, pos, lineWidth);
-                }
-            }
+            Vector3 fromPos = fromObj.GetComponent<RectTransform>().position;
+            Vector3 toPos = toObj.GetComponent<RectTransform>().position;
+            info.line.line.EditPoint(0, fromPos, lineWidth);
+            info.line.line.EditPoint(1, toPos, lineWidth);
         }
     }
 


### PR DESCRIPTION
## Summary
- track connection lines individually instead of grouping by route
- draw each connection with the connected node's route color
- update line positions according to connection list

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687f679b95908333ba99ecf095d44eee