### PR TITLE
完善遊戲流程並建立網路連線客戶端

### DIFF
--- a/Assets/Prefab/GameManager.prefab
+++ b/Assets/Prefab/GameManager.prefab
@@ -12,6 +12,8 @@ GameObject:
   - component: {fileID: 6572753626031551860}
   - component: {fileID: 1601108920700065734}
   - component: {fileID: 8230683092079081292}
+  - component: {fileID: 9123456789012345678}
+  - component: {fileID: 9123456789012345679}
   m_Layer: 0
   m_Name: GameManager
   m_TagString: Untagged
@@ -78,5 +80,33 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: b08ed07128f6bef46a7a43bfe3fbad96, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &9123456789012345678
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6363522763138400275}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: eca876ff7a564fb4f97bf14d8661abc8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  maxPlayers: 12
+  maxRounds: 12
+  treasureGoal: 3
+  selectedMap: {fileID: 0}
+--- !u!114 &9123456789012345679
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6363522763138400275}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a1b2c3d4e5f6789012345678abcdef01, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 

--- a/Assets/Scripts/Editor.meta
+++ b/Assets/Scripts/Editor.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 7f8e9d0c1b2a394857463728190a0b1c
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Editor/GameSetupTests.cs
+++ b/Assets/Scripts/Editor/GameSetupTests.cs
@@ -1,0 +1,45 @@
+#if UNITY_INCLUDE_TESTS
+using NUnit.Framework;
+using UnityEngine;
+
+public class GameSetupTests
+{
+    [Test]
+    public void GameManager_InitializesTwelveParticipants()
+    {
+        var gameObject = new GameObject("GameManagerTest");
+        var gameManager = gameObject.AddComponent<GameManager>();
+        gameManager.useNetworkMode = false;
+        gameManager.regularPoliceCount = 8;
+        gameManager.corruptPoliceCount = 2;
+        gameManager.thiefCount = 2;
+        gameManager.InitializeTeams();
+
+        Assert.AreEqual(12, gameManager.GetAllPlayers().Count);
+        Assert.AreEqual(2, gameManager.GetThieves().Count);
+        Assert.AreEqual(3, gameManager.GetPoliceTeams().Count);
+
+        Object.DestroyImmediate(gameObject);
+    }
+
+    [Test]
+    public void RoomManager_AssignRoles_MatchesConnectedPlayers()
+    {
+        var roomObject = new GameObject("RoomManagerTest");
+        var roomManager = roomObject.AddComponent<RoomManager>();
+        roomManager.CreateRoom(4, 6, 2);
+
+        roomManager.TryAddPlayer(1, "Alice");
+        roomManager.TryAddPlayer(2, "Bob");
+        roomManager.TryAddPlayer(3, "Carol");
+        roomManager.TryAddPlayer(4, "Dave");
+
+        var roster = roomManager.AssignRoles();
+
+        Assert.AreEqual(4, roster.Count);
+        Assert.IsTrue(roomManager.CanStartGame(requireAllReady: false));
+
+        Object.DestroyImmediate(roomObject);
+    }
+}
+#endif

--- a/Assets/Scripts/Editor/GameSetupTests.cs.meta
+++ b/Assets/Scripts/Editor/GameSetupTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 59969c5cc9364acc97ef8d68bee62920
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Editor/TestClientMenu.cs
+++ b/Assets/Scripts/Editor/TestClientMenu.cs
@@ -1,0 +1,54 @@
+#if UNITY_EDITOR
+using UnityEditor;
+using UnityEngine;
+
+public static class TestClientMenu
+{
+    [MenuItem("CorruptPolice/Test Clients/Launch Test Host")]
+    static void LaunchTestHost()
+    {
+        var launcher = EnsureLauncher();
+        launcher.mode = TestClientMode.Host;
+        launcher.playerName = "TestHost";
+        launcher.serverAddress = "127.0.0.1";
+        launcher.autoReady = true;
+        launcher.autoPlay = true;
+        launcher.autoStartGame = true;
+        launcher.minPlayersToStart = 2;
+        launcher.ApplyArgs(launcher.BuildArgsFromInspector());
+        Debug.Log("[TestClient] Test host launcher configured. Enter Play Mode to start.");
+    }
+
+    [MenuItem("CorruptPolice/Test Clients/Launch Test Client")]
+    static void LaunchTestClient()
+    {
+        var launcher = EnsureLauncher();
+        launcher.mode = TestClientMode.Client;
+        launcher.playerName = $"TestClient_{Random.Range(1000, 9999)}";
+        launcher.serverAddress = "127.0.0.1";
+        launcher.autoReady = true;
+        launcher.autoPlay = true;
+        launcher.autoStartGame = false;
+        launcher.ApplyArgs(launcher.BuildArgsFromInspector());
+        Debug.Log("[TestClient] Test client launcher configured. Enter Play Mode to start.");
+    }
+
+    [MenuItem("CorruptPolice/Test Clients/Clear Test Launcher")]
+    static void ClearTestLauncher()
+    {
+        var existing = Object.FindObjectOfType<TestClientLauncher>();
+        if (existing != null)
+            Object.DestroyImmediate(existing.gameObject);
+    }
+
+    static TestClientLauncher EnsureLauncher()
+    {
+        var existing = Object.FindObjectOfType<TestClientLauncher>();
+        if (existing != null)
+            return existing;
+
+        var launcherObject = new GameObject("TestClientLauncher");
+        return launcherObject.AddComponent<TestClientLauncher>();
+    }
+}
+#endif

--- a/Assets/Scripts/Editor/TestClientMenu.cs.meta
+++ b/Assets/Scripts/Editor/TestClientMenu.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1ed5809a1a3d418b825abf3cfbfcc998
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/GameFlowState.cs
+++ b/Assets/Scripts/GameFlowState.cs
@@ -1,0 +1,9 @@
+public enum GameFlowState
+{
+    Local,
+    Lobby,
+    WaitingForPlayers,
+    Placement,
+    Playing,
+    GameOver
+}

--- a/Assets/Scripts/GameFlowState.cs.meta
+++ b/Assets/Scripts/GameFlowState.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c096a2df340b482da3364b3030eec3c6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using UnityEngine;
 
@@ -26,16 +27,33 @@ public class GameManager : MonoBehaviour
     [Tooltip("How many treasures thieves must collect to win")]
     public int treasureGoal = 3;
 
+    [Header("Mode")]
+    [Tooltip("When enabled, wait for network room setup instead of auto-starting locally.")]
+    public bool useNetworkMode = false;
+
     private int treasuresCollected = 0;
     public GameResult Result { get; private set; } = GameResult.None;
 
     public GamePhase CurrentPhase { get; private set; } = GamePhase.Placement;
+    public GameFlowState FlowState { get; private set; } = GameFlowState.Local;
+    public bool IsNetworkMode => useNetworkMode;
+    public PlayerData CurrentTurnPlayer { get; private set; }
+
+    public void SetCurrentTurnPlayer(PlayerData player)
+    {
+        CurrentTurnPlayer = player;
+        OnTurnChanged?.Invoke(player);
+    }
+
+    public event Action<GameFlowState> OnFlowStateChanged;
+    public event Action<PlayerData> OnTurnChanged;
+    public event Action<GameResult> OnGameOver;
 
     private List<PlayerData> placementOrder = new List<PlayerData>();
     private int placementIndex = 0;
 
     [Header("Team Configuration")]
-    [Tooltip("How many police teams participate in the game")] 
+    [Tooltip("How many police teams participate in the game")]
     public int policeTeamCount = 3;
 
     [Header("Player Counts")]
@@ -53,49 +71,99 @@ public class GameManager : MonoBehaviour
     private List<PlayerData> allPlayers = new List<PlayerData>();
 
     public int CurrentRound => currentRound;
+    public int TreasuresCollected => treasuresCollected;
 
     void Awake()
     {
         Instance = this;
-        InitializeTeams();
-        if (PlayerInputController.Instance != null)
-            BeginPlacement();
+        if (!useNetworkMode)
+        {
+            InitializeTeams();
+            if (PlayerInputController.Instance != null)
+                BeginPlacement();
+        }
+        else
+        {
+            SetFlowState(GameFlowState.Lobby);
+        }
     }
 
     void Start()
     {
-        if (MapManager.Instance != null && !MapManager.Instance.autoBuildOnStart)
+        if (MapManager.Instance != null && !MapManager.Instance.autoBuildOnStart && !useNetworkMode)
         {
             MapManager.Instance.BuildMap();
         }
     }
 
-    void InitializeTeams()
+    public void SetFlowState(GameFlowState state)
     {
+        FlowState = state;
+        OnFlowStateChanged?.Invoke(state);
+    }
+
+    public void ResetGameState()
+    {
+        currentRound = 1;
+        treasuresCollected = 0;
+        Result = GameResult.None;
+        CurrentPhase = GamePhase.Placement;
+        gameOver = false;
+        placementIndex = 0;
+        currentTeamTurnIndex = 0;
+        currentPlayerIndex = 0;
+        thiefPhase = true;
+        currentThiefIndex = 0;
+        CurrentTurnPlayer = null;
+        placementOrder.Clear();
+        policeTeams.Clear();
+        thiefPlayers.Clear();
+        allPlayers.Clear();
+    }
+
+    public void InitializeTeams()
+    {
+        ResetGameState();
+
         policeTeams = new List<List<PlayerData>>();
         for (int i = 0; i < policeTeamCount; i++)
             policeTeams.Add(new List<PlayerData>());
 
-        // Create regular police players and distribute them across teams
         for (int i = 0; i < regularPoliceCount; i++)
         {
             int teamIndex = i % policeTeamCount;
             AddPlayer(new PlayerData($"p{i}", PlayerRole.Police, teamIndex));
         }
 
-        // Create corrupt police players
         for (int i = 0; i < corruptPoliceCount; i++)
         {
             int teamIndex = i % policeTeamCount;
             AddPlayer(new PlayerData($"c{i}", PlayerRole.CorruptPolice, teamIndex));
         }
 
-        // Create thief players
         for (int i = 0; i < thiefCount; i++)
         {
             AddThief(new PlayerData($"t{i}", PlayerRole.Thief, -1));
         }
+    }
 
+    public void InitializeFromRoster(IReadOnlyList<PlayerData> roster, RoomConfig config)
+    {
+        ResetGameState();
+        if (config != null)
+            config.ApplyTo(this);
+
+        policeTeams = new List<List<PlayerData>>();
+        for (int i = 0; i < policeTeamCount; i++)
+            policeTeams.Add(new List<PlayerData>());
+
+        foreach (var player in roster)
+        {
+            if (player.role == PlayerRole.Thief)
+                AddThief(player);
+            else
+                AddPlayer(player);
+        }
     }
 
     void AddPlayer(PlayerData player)
@@ -109,7 +177,7 @@ public class GameManager : MonoBehaviour
         thiefPlayers.Add(thief);
         allPlayers.Add(thief);
     }
-    // --- Testing Utilities ---
+
     public void SetPlayerPositions(int[] nodeIds)
     {
         for (int i = 0; i < nodeIds.Length && i < allPlayers.Count; i++)
@@ -121,6 +189,7 @@ public class GameManager : MonoBehaviour
     public void ForceStartGame()
     {
         CurrentPhase = GamePhase.Playing;
+        SetFlowState(GameFlowState.Playing);
         thiefPhase = true;
         currentThiefIndex = 0;
         currentTeamTurnIndex = (currentRound - 1) % policeTeamCount;
@@ -128,9 +197,10 @@ public class GameManager : MonoBehaviour
         NextPlayerTurn();
     }
 
-    void BeginPlacement()
+    public void BeginPlacement()
     {
         CurrentPhase = GamePhase.Placement;
+        SetFlowState(GameFlowState.Placement);
         placementOrder.Clear();
         for (int i = 0; i < policeTeamCount; i++)
         {
@@ -146,12 +216,15 @@ public class GameManager : MonoBehaviour
         if (placementIndex >= placementOrder.Count)
         {
             CurrentPhase = GamePhase.Playing;
+            SetFlowState(GameFlowState.Playing);
             BeginTurn();
             return;
         }
 
         var player = placementOrder[placementIndex];
-        PlayerInputController.Instance.StartPlacement(player);
+        SetCurrentTurnPlayer(player);
+        if (PlayerInputController.Instance != null)
+            PlayerInputController.Instance.StartPlacement(player);
     }
 
     public void ConfirmPlacement()
@@ -183,7 +256,9 @@ public class GameManager : MonoBehaviour
             {
                 var player = thiefPlayers[currentThiefIndex];
                 player.remainingSteps = stepsPerTurn;
-                PlayerInputController.Instance.SetCurrentPlayer(player);
+                SetCurrentTurnPlayer(player);
+                if (PlayerInputController.Instance != null)
+                    PlayerInputController.Instance.SetCurrentPlayer(player);
                 currentThiefIndex++;
             }
             else
@@ -206,7 +281,9 @@ public class GameManager : MonoBehaviour
             {
                 var player = policeTeams[currentTeamTurnIndex][currentPlayerIndex];
                 player.remainingSteps = stepsPerTurn;
-                PlayerInputController.Instance.SetCurrentPlayer(player);
+                SetCurrentTurnPlayer(player);
+                if (PlayerInputController.Instance != null)
+                    PlayerInputController.Instance.SetCurrentPlayer(player);
                 currentPlayerIndex++;
             }
             else
@@ -251,6 +328,26 @@ public class GameManager : MonoBehaviour
         {
             if (thief.currentNodeId == nodeId)
                 return thief;
+        }
+        return null;
+    }
+
+    public PlayerData GetPlayerByClientId(ulong clientId)
+    {
+        foreach (var player in allPlayers)
+        {
+            if (player.clientId == clientId)
+                return player;
+        }
+        return null;
+    }
+
+    public PlayerData GetPlayerByName(string playerName)
+    {
+        foreach (var player in allPlayers)
+        {
+            if (player.playerName == playerName)
+                return player;
         }
         return null;
     }
@@ -322,7 +419,86 @@ public class GameManager : MonoBehaviour
     void GameOver()
     {
         gameOver = true;
+        SetFlowState(GameFlowState.GameOver);
+        OnGameOver?.Invoke(Result);
         Debug.Log($"Game over - {Result} win");
     }
 
+    public bool TryExecuteAction(PlayerData player, int targetNodeId, ActionType action, out string result, out bool isShared, bool advanceTurn = true)
+    {
+        result = string.Empty;
+        isShared = true;
+
+        if (player == null || player.remainingSteps <= 0)
+            return false;
+
+        if (CurrentPhase == GamePhase.Placement)
+        {
+            player.currentNodeId = targetNodeId;
+            if (PlayerTokenManager.Instance != null)
+                PlayerTokenManager.Instance.UpdateTokenPosition(player);
+            return true;
+        }
+
+        if (!MapManager.Instance.AreNodesConnected(player.currentNodeId, targetNodeId))
+            return false;
+
+        player.currentNodeId = targetNodeId;
+        if (PlayerTokenManager.Instance != null)
+            PlayerTokenManager.Instance.UpdateTokenPosition(player);
+
+        player.remainingSteps--;
+
+        if (action == ActionType.Move && player.role == PlayerRole.Thief)
+        {
+            MapManager.Instance.AddFootprint(targetNodeId, player.playerName);
+            bool collected = MapManager.Instance.CollectTreasure(targetNodeId);
+            if (collected)
+            {
+                result = "Found treasure";
+                RecordTreasure();
+            }
+            else
+            {
+                result = "No treasure";
+            }
+        }
+        else if (action == ActionType.Investigate && player.role != PlayerRole.Thief)
+        {
+            var hasClue = MapManager.Instance.HasFootprint(targetNodeId);
+            result = hasClue ? "Found clue" : "No clue";
+            isShared = false;
+        }
+        else if (action == ActionType.Arrest && player.role != PlayerRole.Thief)
+        {
+            var thief = GetThiefAt(targetNodeId);
+            if (thief != null)
+            {
+                ArrestThief(thief);
+                result = $"Arrested ({thief.playerName})";
+            }
+            else
+            {
+                result = "No thief";
+            }
+            isShared = true;
+        }
+
+        if (ActionLogger.Instance != null)
+        {
+            ActionLogger.Instance.Log(
+                player,
+                CurrentRound,
+                targetNodeId,
+                action.ToString(),
+                result,
+                isShared
+            );
+        }
+
+        if (advanceTurn && player.remainingSteps <= 0)
+            NextPlayerTurn();
+
+        return true;
+    }
 }

--- a/Assets/Scripts/GameSystemsBootstrap.cs
+++ b/Assets/Scripts/GameSystemsBootstrap.cs
@@ -1,0 +1,14 @@
+using UnityEngine;
+
+[DefaultExecutionOrder(-200)]
+public class GameSystemsBootstrap : MonoBehaviour
+{
+    void Awake()
+    {
+        if (RoomManager.Instance == null && GetComponent<RoomManager>() == null)
+            gameObject.AddComponent<RoomManager>();
+
+        if (GameManager.Instance != null && GameManager.Instance.useNetworkMode && MapManager.Instance != null)
+            MapManager.Instance.autoBuildOnStart = false;
+    }
+}

--- a/Assets/Scripts/GameSystemsBootstrap.cs.meta
+++ b/Assets/Scripts/GameSystemsBootstrap.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a1b2c3d4e5f6789012345678abcdef01
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: -200
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/MapManager.cs
+++ b/Assets/Scripts/MapManager.cs
@@ -71,22 +71,25 @@ public class MapManager : MonoBehaviour
         }
     }
 
-    public void BuildMap()
+    public void BuildMap(int? seed = null)
     {
-        LoadAndBuildMap();
+        LoadAndBuildMap(seed);
         if (PlayerTokenManager.Instance != null && GameManager.Instance != null)
         {
             PlayerTokenManager.Instance.CreateTokens(GameManager.Instance.GetAllPlayers());
         }
     }
 
-    public void LoadAndBuildMap()
+    public void LoadAndBuildMap(int? seed = null)
     {
         if (mapJsonFile == null)
         {
             Debug.LogError("Map JSON file not assigned.");
             return;
         }
+
+        if (seed.HasValue)
+            Random.InitState(seed.Value);
 
         MapData mapData = JsonUtility.FromJson<MapData>(mapJsonFile.text);
 

--- a/Assets/Scripts/Network.meta
+++ b/Assets/Scripts/Network.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: cca7673bd3904baebad5d96cc6dc1558
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Network/NetworkBootstrap.cs
+++ b/Assets/Scripts/Network/NetworkBootstrap.cs
@@ -1,0 +1,123 @@
+using Unity.Netcode;
+using Unity.Netcode.Transports.UTP;
+using UnityEngine;
+
+public class NetworkBootstrap : MonoBehaviour
+{
+    public static NetworkBootstrap Instance;
+
+    [Header("Transport")]
+    public ushort port = 7777;
+    public string listenAddress = "0.0.0.0";
+
+    void Awake()
+    {
+        if (Instance == null)
+            Instance = this;
+        else
+        {
+            Destroy(gameObject);
+            return;
+        }
+
+        DontDestroyOnLoad(gameObject);
+        EnsureNetworkManager();
+    }
+
+    public bool IsConnected =>
+        NetworkManager.Singleton != null &&
+        (NetworkManager.Singleton.IsClient || NetworkManager.Singleton.IsHost);
+
+    public bool IsHost =>
+        NetworkManager.Singleton != null && NetworkManager.Singleton.IsHost;
+
+    public ulong LocalClientId =>
+        NetworkManager.Singleton != null ? NetworkManager.Singleton.LocalClientId : ulong.MaxValue;
+
+    void EnsureNetworkManager()
+    {
+        if (NetworkManager.Singleton != null)
+            return;
+
+        var networkObject = new GameObject("NetworkManager");
+        networkObject.transform.SetParent(transform);
+
+        var manager = networkObject.AddComponent<NetworkManager>();
+        var transport = networkObject.AddComponent<UnityTransport>();
+        manager.NetworkConfig = new NetworkConfig
+        {
+            NetworkTransport = transport,
+            EnableSceneManagement = false
+        };
+
+        DontDestroyOnLoad(networkObject);
+    }
+
+    UnityTransport GetTransport()
+    {
+        EnsureNetworkManager();
+        return NetworkManager.Singleton.GetComponent<UnityTransport>();
+    }
+
+    public bool StartHostGame()
+    {
+        EnsureNetworkManager();
+        if (NetworkManager.Singleton.IsListening)
+            return true;
+
+        var transport = GetTransport();
+        transport.SetConnectionData(listenAddress, port);
+
+        bool started = NetworkManager.Singleton.StartHost();
+        if (started)
+        {
+            EnsureNetworkSystems();
+            Debug.Log($"Host started on port {port}");
+        }
+        else
+            Debug.LogError("Failed to start host.");
+
+        return started;
+    }
+
+    public bool StartClientGame(string address)
+    {
+        EnsureNetworkManager();
+        if (NetworkManager.Singleton.IsListening)
+            return true;
+
+        if (string.IsNullOrWhiteSpace(address))
+            address = "127.0.0.1";
+
+        var transport = GetTransport();
+        transport.SetConnectionData(address.Trim(), port);
+
+        bool started = NetworkManager.Singleton.StartClient();
+        if (started)
+        {
+            EnsureNetworkSystems();
+            Debug.Log($"Client connecting to {address}:{port}");
+        }
+        else
+            Debug.LogError("Failed to start client.");
+
+        return started;
+    }
+
+    void EnsureNetworkSystems()
+    {
+        if (NetworkSystemsSetup.Instance == null)
+        {
+            var systemsObject = new GameObject("NetworkSystems");
+            systemsObject.AddComponent<NetworkSystemsSetup>();
+        }
+
+        NetworkSystemsSetup.Instance.EnsureSpawned();
+    }
+
+    public void Shutdown()
+    {
+        if (NetworkManager.Singleton != null && NetworkManager.Singleton.IsListening)
+            NetworkManager.Singleton.Shutdown();
+    }
+}

--- a/Assets/Scripts/Network/NetworkBootstrap.cs.meta
+++ b/Assets/Scripts/Network/NetworkBootstrap.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 89d127c7b19548efaf7a93fb66782844
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Network/NetworkGameController.cs
+++ b/Assets/Scripts/Network/NetworkGameController.cs
@@ -1,0 +1,146 @@
+using Unity.Netcode;
+using UnityEngine;
+
+public class NetworkGameController : NetworkBehaviour
+{
+    public static NetworkGameController Instance;
+
+    public override void OnNetworkSpawn()
+    {
+        Instance = this;
+    }
+
+    public bool CanLocalPlayerAct(PlayerData player)
+    {
+        if (player == null || NetworkManager.Singleton == null)
+            return false;
+
+        return player.IsLocalPlayer(NetworkManager.Singleton.LocalClientId);
+    }
+
+    [ClientRpc]
+    public void BeginNetworkGameClientRpc(int seed, NetworkRosterEntry[] rosterPayload)
+    {
+        if (GameManager.Instance == null || RoomManager.Instance == null)
+            return;
+
+        var roster = BuildRosterFromPayload(rosterPayload);
+        GameManager.Instance.useNetworkMode = true;
+        GameManager.Instance.InitializeFromRoster(roster, RoomManager.Instance.ActiveConfig);
+
+        if (MapManager.Instance != null)
+            MapManager.Instance.BuildMap(seed);
+
+        GameManager.Instance.BeginPlacement();
+    }
+
+    [ServerRpc(RequireOwnership = false)]
+    public void SubmitPlacementServerRpc(int nodeId, ServerRpcParams rpcParams = default)
+    {
+        if (!IsServer || GameManager.Instance == null)
+            return;
+
+        var player = GameManager.Instance.GetPlayerByClientId(rpcParams.Receive.SenderClientId);
+        if (player == null || GameManager.Instance.CurrentTurnPlayer != player)
+            return;
+
+        player.currentNodeId = nodeId;
+        if (PlayerTokenManager.Instance != null)
+            PlayerTokenManager.Instance.UpdateTokenPosition(player);
+
+        ConfirmPlacementClientRpc(player.playerName, nodeId);
+    }
+
+    [ServerRpc(RequireOwnership = false)]
+    public void SubmitActionServerRpc(int nodeId, int actionType, ServerRpcParams rpcParams = default)
+    {
+        if (!IsServer || GameManager.Instance == null)
+            return;
+
+        var player = GameManager.Instance.GetPlayerByClientId(rpcParams.Receive.SenderClientId);
+        if (player == null || GameManager.Instance.CurrentTurnPlayer != player)
+            return;
+
+        var action = (ActionType)actionType;
+        if (!GameManager.Instance.TryExecuteAction(player, nodeId, action, out _, out _))
+            return;
+
+        BroadcastActionClientRpc(
+            player.playerName,
+            nodeId,
+            actionType,
+            GameManager.Instance.CurrentRound,
+            GameManager.Instance.TreasuresCollected,
+            (int)GameManager.Instance.Result,
+            GameManager.Instance.CurrentTurnPlayer != null ? GameManager.Instance.CurrentTurnPlayer.playerName : string.Empty
+        );
+    }
+
+    [ClientRpc]
+    void ConfirmPlacementClientRpc(string playerName, int nodeId)
+    {
+        var player = GameManager.Instance?.GetPlayerByName(playerName);
+        if (player == null)
+            return;
+
+        player.currentNodeId = nodeId;
+        if (PlayerTokenManager.Instance != null)
+            PlayerTokenManager.Instance.UpdateTokenPosition(player);
+
+        if (GameManager.Instance.CurrentTurnPlayer == player && PlayerInputController.Instance != null)
+            PlayerInputController.Instance.ApplyPlacementResult(nodeId);
+
+        GameManager.Instance?.ConfirmPlacement();
+    }
+
+    [ClientRpc]
+    void BroadcastActionClientRpc(string playerName, int nodeId, int actionType, int round, int treasuresCollected, int resultCode, string nextPlayerName)
+    {
+        if (IsServer)
+            return;
+
+        ApplyRemoteState(playerName, nodeId, (ActionType)actionType, nextPlayerName, (GameResult)resultCode);
+    }
+
+    void ApplyRemoteState(string actingPlayerName, int nodeId, ActionType action, string nextPlayerName, GameResult result)
+    {
+        if (GameManager.Instance == null)
+            return;
+
+        var actingPlayer = GameManager.Instance.GetPlayerByName(actingPlayerName);
+        if (actingPlayer != null && PlayerInputController.Instance != null)
+        {
+            if (GameManager.Instance.CurrentTurnPlayer == actingPlayer)
+                PlayerInputController.Instance.ApplyRemoteAction(nodeId, action);
+            else if (PlayerTokenManager.Instance != null)
+                PlayerTokenManager.Instance.UpdateTokenPosition(actingPlayer);
+        }
+
+        if (!string.IsNullOrEmpty(nextPlayerName))
+        {
+            var nextPlayer = GameManager.Instance.GetPlayerByName(nextPlayerName);
+            if (nextPlayer != null)
+            {
+                GameManager.Instance.SetCurrentTurnPlayer(nextPlayer);
+                if (PlayerInputController.Instance != null)
+                    PlayerInputController.Instance.SetCurrentPlayer(nextPlayer);
+            }
+        }
+
+        if (result != GameResult.None)
+            GameManager.Instance.SetFlowState(GameFlowState.GameOver);
+    }
+
+    static List<PlayerData> BuildRosterFromPayload(NetworkRosterEntry[] payload)
+    {
+        var roster = new List<PlayerData>();
+        foreach (var entry in payload)
+        {
+            roster.Add(new PlayerData(entry.PlayerName.ToString(), (PlayerRole)entry.Role, entry.TeamIndex)
+            {
+                clientId = entry.ClientId
+            });
+        }
+        return roster;
+    }
+}

--- a/Assets/Scripts/Network/NetworkGameController.cs.meta
+++ b/Assets/Scripts/Network/NetworkGameController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ed6f005fc4924b30abbd8d1aaf920e65
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Network/NetworkRoomManager.cs
+++ b/Assets/Scripts/Network/NetworkRoomManager.cs
@@ -1,0 +1,199 @@
+using System;
+using System.Collections.Generic;
+using Unity.Collections;
+using Unity.Netcode;
+using UnityEngine;
+
+public struct NetworkPlayerSlot : INetworkSerializable, IEquatable<NetworkPlayerSlot>
+{
+    public ulong ClientId;
+    public FixedString32Bytes PlayerName;
+    public bool IsReady;
+
+    public void NetworkSerialize<T>(BufferSerializer<T> serializer) where T : IReaderWriter
+    {
+        serializer.SerializeValue(ref ClientId);
+        serializer.SerializeValue(ref PlayerName);
+        serializer.SerializeValue(ref IsReady);
+    }
+
+    public bool Equals(NetworkPlayerSlot other)
+    {
+        return ClientId == other.ClientId &&
+               PlayerName.Equals(other.PlayerName) &&
+               IsReady == other.IsReady;
+    }
+}
+
+public class NetworkRoomManager : NetworkBehaviour
+{
+    public static NetworkRoomManager Instance;
+
+    private NetworkList<NetworkPlayerSlot> connectedPlayers;
+    private NetworkVariable<int> mapSeed = new NetworkVariable<int>(0);
+    private NetworkVariable<bool> gameStarted = new NetworkVariable<bool>(false);
+
+    public event Action OnLobbyUpdated;
+    public event Action<int> OnNetworkGameStarted;
+
+    void Awake()
+    {
+        connectedPlayers = new NetworkList<NetworkPlayerSlot>();
+    }
+
+    public override void OnNetworkSpawn()
+    {
+        Instance = this;
+        connectedPlayers.OnListChanged += HandleLobbyChanged;
+        gameStarted.OnValueChanged += HandleGameStartedChanged;
+        NetworkManager.Singleton.OnClientDisconnectCallback += HandleClientDisconnect;
+    }
+
+    public override void OnNetworkDespawn()
+    {
+        if (NetworkManager.Singleton != null)
+            NetworkManager.Singleton.OnClientDisconnectCallback -= HandleClientDisconnect;
+
+        connectedPlayers.OnListChanged -= HandleLobbyChanged;
+        gameStarted.OnValueChanged -= HandleGameStartedChanged;
+    }
+
+    void HandleClientDisconnect(ulong clientId)
+    {
+        if (!IsServer)
+            return;
+
+        for (int i = connectedPlayers.Count - 1; i >= 0; i--)
+        {
+            if (connectedPlayers[i].ClientId == clientId)
+                connectedPlayers.RemoveAt(i);
+        }
+
+        if (RoomManager.Instance != null)
+            RoomManager.Instance.RemovePlayer(clientId);
+    }
+
+    void HandleLobbyChanged(NetworkListEvent<NetworkPlayerSlot> changeEvent)
+    {
+        SyncLobbyToRoomManager();
+        OnLobbyUpdated?.Invoke();
+    }
+
+    void HandleGameStartedChanged(bool previous, bool current)
+    {
+        if (current)
+            OnNetworkGameStarted?.Invoke(mapSeed.Value);
+    }
+
+    void SyncLobbyToRoomManager()
+    {
+        if (RoomManager.Instance == null)
+            return;
+
+        RoomManager.Instance.ClearLobby();
+        foreach (var slot in connectedPlayers)
+        {
+            RoomManager.Instance.TryAddPlayer(slot.ClientId, slot.PlayerName.ToString());
+            RoomManager.Instance.SetPlayerReady(slot.ClientId, slot.IsReady);
+        }
+    }
+
+    public IReadOnlyList<NetworkPlayerSlot> GetConnectedPlayers()
+    {
+        var list = new List<NetworkPlayerSlot>();
+        foreach (var slot in connectedPlayers)
+            list.Add(slot);
+        return list;
+    }
+
+    public void RegisterLocalHostPlayer(string playerName)
+    {
+        if (!IsServer)
+            return;
+
+        RegisterPlayerServer(NetworkManager.Singleton.LocalClientId, playerName);
+    }
+
+    [ServerRpc(RequireOwnership = false)]
+    public void JoinRoomServerRpc(FixedString32Bytes playerName, ServerRpcParams rpcParams = default)
+    {
+        RegisterPlayerServer(rpcParams.Receive.SenderClientId, playerName.ToString());
+    }
+
+    [ServerRpc(RequireOwnership = false)]
+    public void SetReadyServerRpc(bool ready, ServerRpcParams rpcParams = default)
+    {
+        ulong clientId = rpcParams.Receive.SenderClientId;
+        for (int i = 0; i < connectedPlayers.Count; i++)
+        {
+            if (connectedPlayers[i].ClientId != clientId)
+                continue;
+
+            var slot = connectedPlayers[i];
+            slot.IsReady = ready;
+            connectedPlayers[i] = slot;
+            if (RoomManager.Instance != null)
+                RoomManager.Instance.SetPlayerReady(clientId, ready);
+            return;
+        }
+    }
+
+    [ServerRpc(RequireOwnership = false)]
+    public void StartGameServerRpc(ServerRpcParams rpcParams = default)
+    {
+        if (!IsServer || gameStarted.Value)
+            return;
+
+        if (rpcParams.Receive.SenderClientId != NetworkManager.Singleton.LocalClientId)
+            return;
+
+        if (RoomManager.Instance == null || GameManager.Instance == null)
+            return;
+
+        if (!RoomManager.Instance.CanStartGame(requireAllReady: false))
+            return;
+
+        mapSeed.Value = UnityEngine.Random.Range(1, int.MaxValue);
+        var roster = RoomManager.Instance.AssignRoles();
+        gameStarted.Value = true;
+        NetworkGameController.Instance.BeginNetworkGameClientRpc(mapSeed.Value, BuildRosterPayload(roster));
+    }
+
+    void RegisterPlayerServer(ulong clientId, string playerName)
+    {
+        if (RoomManager.Instance == null)
+            return;
+
+        if (!RoomManager.Instance.TryAddPlayer(clientId, playerName))
+            return;
+
+        for (int i = 0; i < connectedPlayers.Count; i++)
+        {
+            if (connectedPlayers[i].ClientId == clientId)
+                return;
+        }
+
+        connectedPlayers.Add(new NetworkPlayerSlot
+        {
+            ClientId = clientId,
+            PlayerName = playerName,
+            IsReady = false
+        });
+    }
+
+    NetworkRosterEntry[] BuildRosterPayload(List<PlayerData> roster)
+    {
+        var payload = new NetworkRosterEntry[roster.Count];
+        for (int i = 0; i < roster.Count; i++)
+        {
+            payload[i] = new NetworkRosterEntry
+            {
+                ClientId = roster[i].clientId,
+                PlayerName = roster[i].playerName,
+                Role = (int)roster[i].role,
+                TeamIndex = roster[i].teamIndex
+            };
+        }
+        return payload;
+    }
+}

--- a/Assets/Scripts/Network/NetworkRoomManager.cs.meta
+++ b/Assets/Scripts/Network/NetworkRoomManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a2b47dfe99b04b41a5b2ab97c4710513
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Network/NetworkRosterEntry.cs
+++ b/Assets/Scripts/Network/NetworkRosterEntry.cs
@@ -1,0 +1,27 @@
+using System;
+using Unity.Collections;
+using Unity.Netcode;
+
+public struct NetworkRosterEntry : INetworkSerializable, IEquatable<NetworkRosterEntry>
+{
+    public ulong ClientId;
+    public FixedString32Bytes PlayerName;
+    public int Role;
+    public int TeamIndex;
+
+    public void NetworkSerialize<T>(BufferSerializer<T> serializer) where T : IReaderWriter
+    {
+        serializer.SerializeValue(ref ClientId);
+        serializer.SerializeValue(ref PlayerName);
+        serializer.SerializeValue(ref Role);
+        serializer.SerializeValue(ref TeamIndex);
+    }
+
+    public bool Equals(NetworkRosterEntry other)
+    {
+        return ClientId == other.ClientId &&
+               PlayerName.Equals(other.PlayerName) &&
+               Role == other.Role &&
+               TeamIndex == other.TeamIndex;
+    }
+}

--- a/Assets/Scripts/Network/NetworkRosterEntry.cs.meta
+++ b/Assets/Scripts/Network/NetworkRosterEntry.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1b3b808dee5342008326ca8935c3df8b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Network/NetworkSystemsSetup.cs
+++ b/Assets/Scripts/Network/NetworkSystemsSetup.cs
@@ -1,0 +1,35 @@
+using Unity.Netcode;
+using UnityEngine;
+
+[DefaultExecutionOrder(-100)]
+public class NetworkSystemsSetup : MonoBehaviour
+{
+    public static NetworkSystemsSetup Instance;
+
+    void Awake()
+    {
+        if (Instance == null)
+            Instance = this;
+        else
+        {
+            Destroy(gameObject);
+            return;
+        }
+
+        DontDestroyOnLoad(gameObject);
+
+        if (GetComponent<NetworkObject>() == null)
+            gameObject.AddComponent<NetworkObject>();
+        if (GetComponent<NetworkRoomManager>() == null)
+            gameObject.AddComponent<NetworkRoomManager>();
+        if (GetComponent<NetworkGameController>() == null)
+            gameObject.AddComponent<NetworkGameController>();
+    }
+
+    public void EnsureSpawned()
+    {
+        var networkObject = GetComponent<NetworkObject>();
+        if (networkObject != null && !networkObject.IsSpawned && NetworkManager.Singleton != null && NetworkManager.Singleton.IsServer)
+            networkObject.Spawn();
+    }
+}

--- a/Assets/Scripts/Network/NetworkSystemsSetup.cs.meta
+++ b/Assets/Scripts/Network/NetworkSystemsSetup.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0440109d62fc40fe9e462ab6bf9b55ef
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/PlayerData.cs
+++ b/Assets/Scripts/PlayerData.cs
@@ -13,6 +13,8 @@ public class PlayerData
     public int currentNodeId;
     public int remainingSteps;
     public bool isArrested;
+    public ulong clientId;
+    public int slotIndex;
 
     public PlayerData(string name, PlayerRole role, int teamIndex)
     {
@@ -22,6 +24,13 @@ public class PlayerData
         this.currentNodeId = -1;
         this.remainingSteps = 0;
         this.isArrested = false;
+        this.clientId = ulong.MaxValue;
+        this.slotIndex = -1;
+    }
+
+    public bool IsLocalPlayer(ulong localClientId)
+    {
+        return clientId != ulong.MaxValue && clientId == localClientId;
     }
 
     public void MoveTo(int nodeId)
@@ -29,4 +38,3 @@ public class PlayerData
         currentNodeId = nodeId;
     }
 }
-

--- a/Assets/Scripts/PlayerInputController.cs
+++ b/Assets/Scripts/PlayerInputController.cs
@@ -26,13 +26,31 @@ public class PlayerInputController : MonoBehaviour
     void Awake()
     {
         Instance = this;
-        actionPanel.SetActive(false);
+        if (actionPanel != null)
+            actionPanel.SetActive(false);
 
-        // 為各個按鈕綁定對應的操作方法
-        confirmButton.onClick.AddListener(OnConfirmAction);
-        moveButton.onClick.AddListener(() => SetActionType(ActionType.Move));
-        investigateButton.onClick.AddListener(() => SetActionType(ActionType.Investigate));
-        arrestButton.onClick.AddListener(() => SetActionType(ActionType.Arrest));
+        if (confirmButton != null)
+            confirmButton.onClick.AddListener(OnConfirmAction);
+        if (moveButton != null)
+            moveButton.onClick.AddListener(() => SetActionType(ActionType.Move));
+        if (investigateButton != null)
+            investigateButton.onClick.AddListener(() => SetActionType(ActionType.Investigate));
+        if (arrestButton != null)
+            arrestButton.onClick.AddListener(() => SetActionType(ActionType.Arrest));
+    }
+
+    public bool CanControlCurrentPlayer()
+    {
+        if (currentPlayer == null)
+            return false;
+
+        if (GameManager.Instance != null && GameManager.Instance.IsNetworkMode)
+        {
+            return NetworkGameController.Instance != null &&
+                   NetworkGameController.Instance.CanLocalPlayerAct(currentPlayer);
+        }
+
+        return true;
     }
 
     /// <summary>
@@ -70,6 +88,9 @@ public class PlayerInputController : MonoBehaviour
     /// </summary>
     void HighlightCurrentNode()
     {
+        if (MapManager.Instance == null || currentPlayer == null)
+            return;
+
         foreach (var ui in MapManager.Instance.GetAllNodeUIs())
             ui.Unhighlight();
 
@@ -82,9 +103,21 @@ public class PlayerInputController : MonoBehaviour
     /// </summary>
     public void OnNodeClicked(int nodeId)
     {
+        if (!CanControlCurrentPlayer())
+        {
+            Debug.Log("Waiting for the active player to act.");
+            return;
+        }
+
         if (placementMode)
         {
             if (currentPlayer == null) return;
+
+            if (GameManager.Instance != null && GameManager.Instance.IsNetworkMode)
+            {
+                NetworkGameController.Instance.SubmitPlacementServerRpc(nodeId);
+                return;
+            }
 
             currentPlayer.currentNodeId = nodeId;
             if (PlayerTokenManager.Instance != null)
@@ -115,11 +148,41 @@ public class PlayerInputController : MonoBehaviour
         ShowActionPanel();
     }
 
+    public void ApplyPlacementResult(int nodeId)
+    {
+        if (currentPlayer == null)
+            return;
+
+        currentPlayer.currentNodeId = nodeId;
+        if (PlayerTokenManager.Instance != null)
+            PlayerTokenManager.Instance.UpdateTokenPosition(currentPlayer);
+
+        MapManager.Instance.GetNodeUI(nodeId)?.Highlight();
+        placementMode = false;
+    }
+
+    public void ApplyRemoteAction(int nodeId, ActionType action)
+    {
+        if (currentPlayer == null || GameManager.Instance == null)
+            return;
+
+        selectedNodeId = nodeId;
+        currentAction = action;
+        GameManager.Instance.TryExecuteAction(currentPlayer, nodeId, action, out _, out _, advanceTurn: false);
+
+        if (actionPanel != null)
+            actionPanel.SetActive(false);
+        selectedNodeId = -1;
+    }
+
     /// <summary>
     /// 顯示行動選單，依照角色開啟對應選項
     /// </summary>
     void ShowActionPanel()
     {
+        if (actionPanel == null)
+            return;
+
         actionPanel.SetActive(true);
         moveButton.gameObject.SetActive(currentPlayer.role == PlayerRole.Thief);
         investigateButton.gameObject.SetActive(currentPlayer.role != PlayerRole.Thief);
@@ -141,74 +204,42 @@ public class PlayerInputController : MonoBehaviour
     {
         if (selectedNodeId == -1 || currentPlayer == null) return;
 
-        currentPlayer.currentNodeId = selectedNodeId;
-        if (PlayerTokenManager.Instance != null)
-            PlayerTokenManager.Instance.UpdateTokenPosition(currentPlayer);
+        if (!CanControlCurrentPlayer())
+            return;
 
-        currentPlayer.remainingSteps--;
+        if (GameManager.Instance != null && GameManager.Instance.IsNetworkMode)
+        {
+            NetworkGameController.Instance.SubmitActionServerRpc(selectedNodeId, (int)currentAction);
+            if (actionPanel != null)
+                actionPanel.SetActive(false);
+            selectedNodeId = -1;
+            return;
+        }
 
-        int round = GameManager.Instance != null ? GameManager.Instance.CurrentRound : -1;
-        Debug.Log($"[Action] Round {round} - {currentPlayer.playerName} performed {currentAction} on node {selectedNodeId}. Remaining steps: {currentPlayer.remainingSteps}");
+        ExecuteConfirmedAction(true);
+    }
 
-        string result = string.Empty;
-        bool isShared = true;
-        if (currentAction == ActionType.Move && currentPlayer.role == PlayerRole.Thief)
+    void ExecuteConfirmedAction(bool advanceTurnLocally)
+    {
+        if (selectedNodeId == -1 || currentPlayer == null)
+            return;
+
+        if (GameManager.Instance != null)
         {
-            MapManager.Instance.AddFootprint(selectedNodeId, currentPlayer.playerName);
-            bool collected = MapManager.Instance.CollectTreasure(selectedNodeId);
-            if (collected)
-            {
-                result = "Found treasure";
-                if (GameManager.Instance != null)
-                    GameManager.Instance.RecordTreasure();
-            }
-            else
-            {
-                result = "No treasure";
-            }
-        }
-        else if (currentAction == ActionType.Investigate && currentPlayer.role != PlayerRole.Thief)
-        {
-            var hasClue = MapManager.Instance.HasFootprint(selectedNodeId);
-            result = hasClue ? "Found clue" : "No clue";
-            isShared = false;
-        }
-        else if (currentAction == ActionType.Arrest && currentPlayer.role != PlayerRole.Thief)
-        {
-            var thief = GameManager.Instance.GetThiefAt(selectedNodeId);
-            if (thief != null)
-            {
-                GameManager.Instance.ArrestThief(thief);
-                result = $"Arrested ({thief.playerName})";
-            }
-            else
-            {
-                result = "No thief";
-            }
-            isShared = true;
-        }
-        if (ActionLogger.Instance != null)
-        {
-            ActionLogger.Instance.Log(
-                currentPlayer,
-                GameManager.Instance.CurrentRound,
-                selectedNodeId,
-                currentAction.ToString(),
-                result,
-                isShared
-            );
+            GameManager.Instance.TryExecuteAction(currentPlayer, selectedNodeId, currentAction, out _, out _);
         }
         else
         {
-            Debug.LogWarning("ActionLogger instance missing - skipping log entry.");
+            currentPlayer.currentNodeId = selectedNodeId;
+            if (PlayerTokenManager.Instance != null)
+                PlayerTokenManager.Instance.UpdateTokenPosition(currentPlayer);
+            currentPlayer.remainingSteps--;
+            if (advanceTurnLocally && currentPlayer.remainingSteps <= 0 && GameManager.Instance != null)
+                GameManager.Instance.NextPlayerTurn();
         }
 
-        if (currentPlayer.remainingSteps <= 0)
-        {
-            GameManager.Instance.NextPlayerTurn();
-        }
-
-        actionPanel.SetActive(false);
+        if (actionPanel != null)
+            actionPanel.SetActive(false);
         selectedNodeId = -1;
     }
 }

--- a/Assets/Scripts/RoomConfig.cs
+++ b/Assets/Scripts/RoomConfig.cs
@@ -1,0 +1,45 @@
+using System;
+using UnityEngine;
+
+[Serializable]
+public class RoomConfig
+{
+    public int maxPlayers = 12;
+    public int maxRounds = 12;
+    public int treasureGoal = 3;
+    public int stepsPerTurn = 1;
+    public int policeTeamCount = 3;
+    public int regularPoliceCount = 8;
+    public int corruptPoliceCount = 2;
+    public int thiefCount = 2;
+    public int mapSeed = 0;
+
+    public void ApplyTo(GameManager gameManager)
+    {
+        if (gameManager == null)
+            return;
+
+        gameManager.maxRounds = maxRounds;
+        gameManager.treasureGoal = treasureGoal;
+        gameManager.stepsPerTurn = stepsPerTurn;
+        gameManager.policeTeamCount = policeTeamCount;
+        gameManager.regularPoliceCount = regularPoliceCount;
+        gameManager.corruptPoliceCount = corruptPoliceCount;
+        gameManager.thiefCount = thiefCount;
+    }
+
+    public static RoomConfig FromGameManager(GameManager gameManager)
+    {
+        return new RoomConfig
+        {
+            maxPlayers = gameManager.regularPoliceCount + gameManager.corruptPoliceCount + gameManager.thiefCount,
+            maxRounds = gameManager.maxRounds,
+            treasureGoal = gameManager.treasureGoal,
+            stepsPerTurn = gameManager.stepsPerTurn,
+            policeTeamCount = gameManager.policeTeamCount,
+            regularPoliceCount = gameManager.regularPoliceCount,
+            corruptPoliceCount = gameManager.corruptPoliceCount,
+            thiefCount = gameManager.thiefCount
+        };
+    }
+}

--- a/Assets/Scripts/RoomConfig.cs.meta
+++ b/Assets/Scripts/RoomConfig.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3a0c23426dc347488cbd07873c9f8ee4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/RoomManager.cs
+++ b/Assets/Scripts/RoomManager.cs
@@ -1,17 +1,193 @@
-// 房間與玩家配置管理
+using System;
 using System.Collections.Generic;
 using UnityEngine;
 
 public class RoomManager : MonoBehaviour
 {
-    public int maxPlayers;
-    public int maxRounds;
-    public int treasureGoal;
-    //public List<PlayerData> players;
-    public MapNodeData selectedMap;
+    public static RoomManager Instance;
 
-    public void CreateRoom(int playerCount, int roundLimit, int treasureTarget) { }
-    public void AssignRoles() { }
-    public void StartGame() { }
+    [Header("Defaults")]
+    public RoomConfig defaultConfig = new RoomConfig();
+
+    public RoomConfig ActiveConfig { get; private set; }
+    public IReadOnlyList<LobbyPlayer> LobbyPlayers => lobbyPlayers;
+
+    public event Action OnLobbyChanged;
+    public event Action OnGameStarting;
+
+    private readonly List<LobbyPlayer> lobbyPlayers = new List<LobbyPlayer>();
+
+    void Awake()
+    {
+        if (Instance == null)
+            Instance = this;
+        else
+            Destroy(gameObject);
+
+        ActiveConfig = CloneConfig(defaultConfig);
+    }
+
+    public void CreateRoom(int playerCount, int roundLimit, int treasureTarget)
+    {
+        ActiveConfig = CloneConfig(defaultConfig);
+        ActiveConfig.maxPlayers = Mathf.Clamp(playerCount, 2, 12);
+        ActiveConfig.maxRounds = Mathf.Max(1, roundLimit);
+        ActiveConfig.treasureGoal = Mathf.Max(1, treasureTarget);
+        lobbyPlayers.Clear();
+        OnLobbyChanged?.Invoke();
+    }
+
+    public void UpdateConfig(RoomConfig config)
+    {
+        ActiveConfig = CloneConfig(config);
+        OnLobbyChanged?.Invoke();
+    }
+
+    public bool TryAddPlayer(ulong clientId, string playerName)
+    {
+        if (FindLobbyPlayer(clientId) != null)
+            return true;
+
+        if (lobbyPlayers.Count >= ActiveConfig.maxPlayers)
+            return false;
+
+        lobbyPlayers.Add(new LobbyPlayer
+        {
+            clientId = clientId,
+            playerName = playerName,
+            isReady = false
+        });
+        OnLobbyChanged?.Invoke();
+        return true;
+    }
+
+    public void RemovePlayer(ulong clientId)
+    {
+        lobbyPlayers.RemoveAll(p => p.clientId == clientId);
+        OnLobbyChanged?.Invoke();
+    }
+
+    public void SetPlayerReady(ulong clientId, bool ready)
+    {
+        var player = FindLobbyPlayer(clientId);
+        if (player == null)
+            return;
+
+        player.isReady = ready;
+        OnLobbyChanged?.Invoke();
+    }
+
+    public bool CanStartGame(bool requireAllReady)
+    {
+        if (lobbyPlayers.Count < 2)
+            return false;
+
+        if (!requireAllReady)
+            return true;
+
+        foreach (var player in lobbyPlayers)
+        {
+            if (!player.isReady)
+                return false;
+        }
+
+        return true;
+    }
+
+    public List<PlayerData> AssignRoles()
+    {
+        var roster = new List<PlayerData>();
+        int playerCount = lobbyPlayers.Count;
+        int thiefTotal = Mathf.Clamp(ActiveConfig.thiefCount, 1, Mathf.Max(1, playerCount / 4));
+        int corruptTotal = Mathf.Clamp(ActiveConfig.corruptPoliceCount, 0, playerCount - thiefTotal);
+        int policeTotal = playerCount - thiefTotal - corruptTotal;
+
+        var shuffled = new List<LobbyPlayer>(lobbyPlayers);
+        Shuffle(shuffled);
+
+        int index = 0;
+        for (int i = 0; i < policeTotal; i++, index++)
+        {
+            var lobbyPlayer = shuffled[index];
+            var player = new PlayerData(lobbyPlayer.playerName, PlayerRole.Police, i % ActiveConfig.policeTeamCount)
+            {
+                clientId = lobbyPlayer.clientId,
+                slotIndex = index
+            };
+            roster.Add(player);
+        }
+
+        for (int i = 0; i < corruptTotal; i++, index++)
+        {
+            var lobbyPlayer = shuffled[index];
+            var player = new PlayerData(lobbyPlayer.playerName, PlayerRole.CorruptPolice, i % ActiveConfig.policeTeamCount)
+            {
+                clientId = lobbyPlayer.clientId,
+                slotIndex = index
+            };
+            roster.Add(player);
+        }
+
+        for (int i = 0; i < thiefTotal; i++, index++)
+        {
+            var lobbyPlayer = shuffled[index];
+            var player = new PlayerData(lobbyPlayer.playerName, PlayerRole.Thief, -1)
+            {
+                clientId = lobbyPlayer.clientId,
+                slotIndex = index
+            };
+            roster.Add(player);
+        }
+
+        return roster;
+    }
+
+    public void StartGame()
+    {
+        OnGameStarting?.Invoke();
+    }
+
+    public LobbyPlayer FindLobbyPlayer(ulong clientId)
+    {
+        return lobbyPlayers.Find(p => p.clientId == clientId);
+    }
+
+    public void ClearLobby()
+    {
+        lobbyPlayers.Clear();
+        OnLobbyChanged?.Invoke();
+    }
+
+    static RoomConfig CloneConfig(RoomConfig source)
+    {
+        return new RoomConfig
+        {
+            maxPlayers = source.maxPlayers,
+            maxRounds = source.maxRounds,
+            treasureGoal = source.treasureGoal,
+            stepsPerTurn = source.stepsPerTurn,
+            policeTeamCount = source.policeTeamCount,
+            regularPoliceCount = source.regularPoliceCount,
+            corruptPoliceCount = source.corruptPoliceCount,
+            thiefCount = source.thiefCount,
+            mapSeed = source.mapSeed
+        };
+    }
+
+    static void Shuffle<T>(IList<T> list)
+    {
+        for (int i = list.Count - 1; i > 0; i--)
+        {
+            int j = UnityEngine.Random.Range(0, i + 1);
+            (list[i], list[j]) = (list[j], list[i]);
+        }
+    }
 }
 
+[Serializable]
+public class LobbyPlayer
+{
+    public ulong clientId;
+    public string playerName;
+    public bool isReady;
+}

--- a/Assets/Scripts/Test/TestClientArgs.cs
+++ b/Assets/Scripts/Test/TestClientArgs.cs
@@ -1,0 +1,119 @@
+using System;
+using UnityEngine;
+
+public enum TestClientMode
+{
+    None,
+    Host,
+    Client
+}
+
+[Serializable]
+public class TestClientArgs
+{
+    public TestClientMode mode = TestClientMode.None;
+    public string serverAddress = "127.0.0.1";
+    public string playerName = "";
+    public bool autoReady = true;
+    public bool autoPlay = true;
+    public bool autoStartGame = true;
+    public int minPlayersToStart = 2;
+    public float actionDelaySeconds = 0.75f;
+    public float connectRetrySeconds = 0.5f;
+    public int maxConnectAttempts = 60;
+
+    public static TestClientArgs Parse()
+    {
+        var args = new TestClientArgs();
+        string[] commandLine = Environment.GetCommandLineArgs();
+
+        for (int i = 0; i < commandLine.Length; i++)
+        {
+            string token = commandLine[i].ToLowerInvariant();
+            switch (token)
+            {
+                case "-testclient":
+                case "--test-client":
+                    args.mode = TestClientMode.Client;
+                    break;
+                case "-testhost":
+                case "--test-host":
+                    args.mode = TestClientMode.Host;
+                    break;
+                case "-address":
+                case "--address":
+                    if (i + 1 < commandLine.Length)
+                        args.serverAddress = commandLine[++i];
+                    break;
+                case "-name":
+                case "--name":
+                    if (i + 1 < commandLine.Length)
+                        args.playerName = commandLine[++i];
+                    break;
+                case "-autoready":
+                case "--auto-ready":
+                    if (i + 1 < commandLine.Length)
+                        args.autoReady = ParseBool(commandLine[++i], true);
+                    break;
+                case "-autoplay":
+                case "--auto-play":
+                    if (i + 1 < commandLine.Length)
+                        args.autoPlay = ParseBool(commandLine[++i], true);
+                    break;
+                case "-autostart":
+                case "--auto-start":
+                    if (i + 1 < commandLine.Length)
+                        args.autoStartGame = ParseBool(commandLine[++i], true);
+                    break;
+                case "-minplayers":
+                case "--min-players":
+                    if (i + 1 < commandLine.Length && int.TryParse(commandLine[++i], out int minPlayers))
+                        args.minPlayersToStart = Mathf.Max(2, minPlayers);
+                    break;
+                case "-delay":
+                case "--delay":
+                    if (i + 1 < commandLine.Length && float.TryParse(commandLine[++i], out float delay))
+                        args.actionDelaySeconds = Mathf.Max(0.1f, delay);
+                    break;
+            }
+        }
+
+        if (args.mode != TestClientMode.None && string.IsNullOrWhiteSpace(args.playerName))
+        {
+            args.playerName = args.mode == TestClientMode.Host
+                ? "TestHost"
+                : $"TestClient_{UnityEngine.Random.Range(1000, 9999)}";
+        }
+
+        return args;
+    }
+
+    static bool ParseBool(string value, bool defaultValue)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return defaultValue;
+
+        if (bool.TryParse(value, out bool parsed))
+            return parsed;
+
+        return value == "1" || value == "yes" || value == "on";
+    }
+}
+
+public static class TestClientRuntime
+{
+    [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterSceneLoad)]
+    static void BootstrapFromCommandLine()
+    {
+        var args = TestClientArgs.Parse();
+        if (args.mode == TestClientMode.None)
+            return;
+
+        if (UnityEngine.Object.FindObjectOfType<TestClientLauncher>() != null)
+            return;
+
+        var launcherObject = new GameObject("TestClientLauncher");
+        var launcher = launcherObject.AddComponent<TestClientLauncher>();
+        launcher.ApplyArgs(args);
+    }
+}

--- a/Assets/Scripts/Test/TestClientArgs.cs.meta
+++ b/Assets/Scripts/Test/TestClientArgs.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 62cabd8aeac24a1c876848ef3cc89ad9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Test/TestClientBot.cs
+++ b/Assets/Scripts/Test/TestClientBot.cs
@@ -1,0 +1,76 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+public static class TestClientBot
+{
+    public static bool TryGetPlacementNode(PlayerData player, out int nodeId)
+    {
+        nodeId = -1;
+        if (MapManager.Instance == null)
+            return false;
+
+        var nodes = MapManager.Instance.GetAllNodeUIs();
+        if (nodes == null || nodes.Count == 0)
+            return false;
+
+        int index = player != null && player.slotIndex >= 0
+            ? player.slotIndex % nodes.Count
+            : Random.Range(0, nodes.Count);
+
+        nodeId = nodes[index].nodeId;
+        return true;
+    }
+
+    public static bool TryGetTurnAction(PlayerData player, out int targetNodeId, out ActionType action)
+    {
+        targetNodeId = -1;
+        action = ActionType.Move;
+
+        if (player == null || MapManager.Instance == null || GameManager.Instance == null)
+            return false;
+
+        var neighbors = GetReachableNeighbors(player);
+        if (neighbors.Count == 0)
+            return false;
+
+        if (player.role == PlayerRole.Thief)
+        {
+            targetNodeId = neighbors[Random.Range(0, neighbors.Count)];
+            action = ActionType.Move;
+            return true;
+        }
+
+        foreach (int node in neighbors)
+        {
+            if (GameManager.Instance.GetThiefAt(node) != null)
+            {
+                targetNodeId = node;
+                action = ActionType.Arrest;
+                return true;
+            }
+        }
+
+        targetNodeId = neighbors[Random.Range(0, neighbors.Count)];
+        action = ActionType.Investigate;
+        return true;
+    }
+
+    static List<int> GetReachableNeighbors(PlayerData player)
+    {
+        var results = new List<int>();
+        if (player.currentNodeId < 0)
+            return results;
+
+        var nodeData = MapManager.Instance.GetNodeData(player.currentNodeId);
+        if (nodeData?.neighbors == null)
+            return results;
+
+        foreach (int neighbor in nodeData.neighbors)
+        {
+            if (MapManager.Instance.AreNodesConnected(player.currentNodeId, neighbor))
+                results.Add(neighbor);
+        }
+
+        return results;
+    }
+}

--- a/Assets/Scripts/Test/TestClientBot.cs.meta
+++ b/Assets/Scripts/Test/TestClientBot.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 56f38c390e714c85845486f286200301
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Test/TestClientLauncher.cs
+++ b/Assets/Scripts/Test/TestClientLauncher.cs
@@ -1,0 +1,264 @@
+using System.Collections;
+using Unity.Collections;
+using Unity.Netcode;
+using UnityEngine;
+
+public class TestClientLauncher : MonoBehaviour
+{
+    [Header("Mode")]
+    public TestClientMode mode = TestClientMode.None;
+    public string serverAddress = "127.0.0.1";
+    public string playerName = "TestClient";
+
+    [Header("Automation")]
+    public bool autoReady = true;
+    public bool autoPlay = true;
+    public bool autoStartGame = true;
+    public int minPlayersToStart = 2;
+    public float actionDelaySeconds = 0.75f;
+    public float connectRetrySeconds = 0.5f;
+    public int maxConnectAttempts = 60;
+
+    private TestClientArgs activeArgs;
+    private bool hasJoinedLobby;
+    private bool hasMarkedReady;
+    private bool hasRequestedGameStart;
+    private Coroutine connectRoutine;
+    private Coroutine actionRoutine;
+
+    void Start()
+    {
+        if (mode == TestClientMode.None || connectRoutine != null)
+            return;
+
+        activeArgs = BuildArgsFromInspector();
+        connectRoutine = StartCoroutine(BootstrapRoutine());
+    }
+
+    void OnEnable()
+    {
+        if (GameManager.Instance != null)
+        {
+            GameManager.Instance.OnTurnChanged += HandleTurnChanged;
+            GameManager.Instance.OnFlowStateChanged += HandleFlowStateChanged;
+        }
+    }
+
+    void OnDisable()
+    {
+        if (GameManager.Instance != null)
+        {
+            GameManager.Instance.OnTurnChanged -= HandleTurnChanged;
+            GameManager.Instance.OnFlowStateChanged -= HandleFlowStateChanged;
+        }
+    }
+
+    public void ApplyArgs(TestClientArgs args)
+    {
+        activeArgs = args;
+        mode = args.mode;
+        serverAddress = args.serverAddress;
+        playerName = args.playerName;
+        autoReady = args.autoReady;
+        autoPlay = args.autoPlay;
+        autoStartGame = args.autoStartGame;
+        minPlayersToStart = args.minPlayersToStart;
+        actionDelaySeconds = args.actionDelaySeconds;
+        connectRetrySeconds = args.connectRetrySeconds;
+        maxConnectAttempts = args.maxConnectAttempts;
+
+        if (connectRoutine == null && isActiveAndEnabled)
+            connectRoutine = StartCoroutine(BootstrapRoutine());
+    }
+
+    public TestClientArgs BuildArgsFromInspector()
+    {
+        return new TestClientArgs
+        {
+            mode = mode,
+            serverAddress = serverAddress,
+            playerName = playerName,
+            autoReady = autoReady,
+            autoPlay = autoPlay,
+            autoStartGame = autoStartGame,
+            minPlayersToStart = minPlayersToStart,
+            actionDelaySeconds = actionDelaySeconds,
+            connectRetrySeconds = connectRetrySeconds,
+            maxConnectAttempts = maxConnectAttempts
+        };
+    }
+
+    IEnumerator BootstrapRoutine()
+    {
+        if (activeArgs == null)
+            activeArgs = BuildArgsFromInspector();
+
+        PrepareNetworkSession();
+
+        if (NetworkBootstrap.Instance == null)
+        {
+            var bootstrapObject = new GameObject("NetworkBootstrap");
+            bootstrapObject.AddComponent<NetworkBootstrap>();
+        }
+
+        bool started = activeArgs.mode == TestClientMode.Host
+            ? NetworkBootstrap.Instance.StartHostGame()
+            : NetworkBootstrap.Instance.StartClientGame(activeArgs.serverAddress);
+
+        if (!started)
+        {
+            Debug.LogError("[TestClient] Failed to start network session.");
+            yield break;
+        }
+
+        int attempts = 0;
+        while (attempts < activeArgs.maxConnectAttempts)
+        {
+            if (NetworkManager.Singleton != null &&
+                NetworkManager.Singleton.IsConnectedClient &&
+                NetworkRoomManager.Instance != null &&
+                NetworkRoomManager.Instance.IsSpawned)
+            {
+                break;
+            }
+
+            attempts++;
+            yield return new WaitForSeconds(activeArgs.connectRetrySeconds);
+        }
+
+        if (NetworkRoomManager.Instance == null || !NetworkRoomManager.Instance.IsSpawned)
+        {
+            Debug.LogError("[TestClient] NetworkRoomManager did not become available.");
+            yield break;
+        }
+
+        if (activeArgs.mode == TestClientMode.Host)
+        {
+            NetworkRoomManager.Instance.RegisterLocalHostPlayer(activeArgs.playerName);
+            hasJoinedLobby = true;
+            Debug.Log($"[TestClient] Host ready as {activeArgs.playerName}");
+        }
+        else
+        {
+            NetworkRoomManager.Instance.JoinRoomServerRpc(new FixedString32Bytes(activeArgs.playerName));
+            hasJoinedLobby = true;
+            Debug.Log($"[TestClient] Joined lobby as {activeArgs.playerName}");
+        }
+
+        if (activeArgs.autoReady)
+            yield return MarkReadyWhenJoined();
+
+        if (activeArgs.mode == TestClientMode.Host && activeArgs.autoStartGame)
+            StartCoroutine(AutoStartGameRoutine());
+    }
+
+    IEnumerator MarkReadyWhenJoined()
+    {
+        yield return new WaitForSeconds(activeArgs.actionDelaySeconds);
+
+        if (hasMarkedReady || NetworkRoomManager.Instance == null)
+            yield break;
+
+        NetworkRoomManager.Instance.SetReadyServerRpc(true);
+        hasMarkedReady = true;
+        Debug.Log($"[TestClient] {activeArgs.playerName} is ready.");
+    }
+
+    IEnumerator AutoStartGameRoutine()
+    {
+        while (!hasRequestedGameStart)
+        {
+            if (NetworkRoomManager.Instance == null)
+            {
+                yield return new WaitForSeconds(activeArgs.connectRetrySeconds);
+                continue;
+            }
+
+            int playerCount = NetworkRoomManager.Instance.GetConnectedPlayers().Count;
+            if (playerCount >= activeArgs.minPlayersToStart)
+            {
+                yield return new WaitForSeconds(activeArgs.actionDelaySeconds);
+                NetworkRoomManager.Instance.StartGameServerRpc();
+                hasRequestedGameStart = true;
+                Debug.Log($"[TestClient] Host auto-started game with {playerCount} players.");
+                yield break;
+            }
+
+            yield return new WaitForSeconds(activeArgs.connectRetrySeconds);
+        }
+    }
+
+    void HandleFlowStateChanged(GameFlowState state)
+    {
+        if (!activeArgs.autoPlay || state != GameFlowState.Placement)
+            return;
+
+        TryScheduleBotAction(GameManager.Instance != null ? GameManager.Instance.CurrentTurnPlayer : null);
+    }
+
+    void HandleTurnChanged(PlayerData player)
+    {
+        if (!activeArgs.autoPlay)
+            return;
+
+        TryScheduleBotAction(player);
+    }
+
+    void TryScheduleBotAction(PlayerData player)
+    {
+        if (player == null || NetworkManager.Singleton == null)
+            return;
+
+        if (!player.IsLocalPlayer(NetworkManager.Singleton.LocalClientId))
+            return;
+
+        if (actionRoutine != null)
+            StopCoroutine(actionRoutine);
+
+        actionRoutine = StartCoroutine(PerformBotActionRoutine(player));
+    }
+
+    IEnumerator PerformBotActionRoutine(PlayerData player)
+    {
+        yield return new WaitForSeconds(activeArgs.actionDelaySeconds);
+
+        if (player == null || NetworkGameController.Instance == null || GameManager.Instance == null)
+            yield break;
+
+        if (!player.IsLocalPlayer(NetworkManager.Singleton.LocalClientId))
+            yield break;
+
+        if (GameManager.Instance.FlowState == GameFlowState.Placement &&
+            GameManager.Instance.CurrentPhase == GamePhase.Placement)
+        {
+            if (TestClientBot.TryGetPlacementNode(player, out int placementNode))
+            {
+                Debug.Log($"[TestClient] {player.playerName} placing at node {placementNode}");
+                NetworkGameController.Instance.SubmitPlacementServerRpc(placementNode);
+            }
+            yield break;
+        }
+
+        if (GameManager.Instance.FlowState != GameFlowState.Playing)
+            yield break;
+
+        if (TestClientBot.TryGetTurnAction(player, out int targetNodeId, out ActionType action))
+        {
+            Debug.Log($"[TestClient] {player.playerName} performing {action} on node {targetNodeId}");
+            NetworkGameController.Instance.SubmitActionServerRpc(targetNodeId, (int)action);
+        }
+    }
+
+    static void PrepareNetworkSession()
+    {
+        if (GameManager.Instance != null)
+        {
+            GameManager.Instance.useNetworkMode = true;
+            GameManager.Instance.ResetGameState();
+            GameManager.Instance.SetFlowState(GameFlowState.Lobby);
+        }
+
+        if (MapManager.Instance != null)
+            MapManager.Instance.autoBuildOnStart = false;
+    }
+}

--- a/Assets/Scripts/Test/TestClientLauncher.cs.meta
+++ b/Assets/Scripts/Test/TestClientLauncher.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: debe238b16fe4999b179ad5250264be1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Test/TestLauncher.cs
+++ b/Assets/Scripts/Test/TestLauncher.cs
@@ -7,22 +7,17 @@ public class TestLauncher : MonoBehaviour
 
     void Start()
     {
-        if (mapManager == null) mapManager = MapManager.Instance;
         if (gameManager == null) gameManager = GameManager.Instance;
+        if (mapManager == null) mapManager = MapManager.Instance;
 
-        //mapManager.LoadAndBuildMap();
-
-        //GenerateTestPlayers();
-        
+        if (gameManager != null && gameManager.useNetworkMode)
+            return;
 
         int[] startNodes = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 };
 
         gameManager.SetPlayerPositions(startNodes);
 
         gameManager.ForceStartGame();
-
-        //gameManager.BeginTurn();  // ݭnTO GameManager  BeginTurn O public
-
     }
 
     void GenerateTestPlayers()

--- a/Assets/Scripts/Test/launch_test_clients.sh
+++ b/Assets/Scripts/Test/launch_test_clients.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Launch one test host and multiple automated test clients for CorruptPolice builds.
+#
+# Usage:
+#   ./launch_test_clients.sh /path/to/CorruptPolice.exe 3
+#
+# Arguments:
+#   $1 - Path to the built game executable
+#   $2 - Number of test clients to launch (default: 2)
+
+BUILD_PATH="${1:-}"
+CLIENT_COUNT="${2:-2}"
+ADDRESS="${ADDRESS:-127.0.0.1}"
+DELAY="${DELAY:-0.75}"
+
+if [[ -z "${BUILD_PATH}" ]]; then
+  echo "Usage: $0 /path/to/CorruptPolice.exe [client_count]"
+  exit 1
+fi
+
+if [[ ! -x "${BUILD_PATH}" ]]; then
+  echo "Executable not found or not executable: ${BUILD_PATH}"
+  exit 1
+fi
+
+echo "Starting test host..."
+"${BUILD_PATH}" -testhost -name TestHost -autostart true -minplayers "${CLIENT_COUNT}" -delay "${DELAY}" &
+HOST_PID=$!
+
+sleep 2
+
+for ((i=1; i<=CLIENT_COUNT; i++)); do
+  echo "Starting test client ${i}..."
+  "${BUILD_PATH}" -testclient -address "${ADDRESS}" -name "TestClient_${i}" -autoready true -autoplay true -delay "${DELAY}" &
+  sleep 1
+done
+
+echo "Host PID: ${HOST_PID}"
+echo "Launched ${CLIENT_COUNT} test client(s). Press Ctrl+C to stop."
+
+wait "${HOST_PID}"

--- a/Assets/Scripts/UI.meta
+++ b/Assets/Scripts/UI.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 6bd7ad6bc2c84b4e934817754547a850
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/UI/GameFlowUI.cs
+++ b/Assets/Scripts/UI/GameFlowUI.cs
@@ -1,0 +1,101 @@
+using UnityEngine;
+using TMPro;
+
+public class GameFlowUI : MonoBehaviour
+{
+    public TMP_Text phaseLabel;
+    public TMP_Text turnLabel;
+    public TMP_Text roundLabel;
+    public TMP_Text resultLabel;
+    public GameObject resultPanel;
+
+    void OnEnable()
+    {
+        if (GameManager.Instance != null)
+        {
+            GameManager.Instance.OnFlowStateChanged += HandleFlowStateChanged;
+            GameManager.Instance.OnTurnChanged += HandleTurnChanged;
+            GameManager.Instance.OnGameOver += HandleGameOver;
+            RefreshAll();
+        }
+    }
+
+    void OnDisable()
+    {
+        if (GameManager.Instance != null)
+        {
+            GameManager.Instance.OnFlowStateChanged -= HandleFlowStateChanged;
+            GameManager.Instance.OnTurnChanged -= HandleTurnChanged;
+            GameManager.Instance.OnGameOver -= HandleGameOver;
+        }
+    }
+
+    void HandleFlowStateChanged(GameFlowState state)
+    {
+        if (phaseLabel != null)
+        {
+            phaseLabel.text = state switch
+            {
+                GameFlowState.Lobby => "大廳",
+                GameFlowState.Placement => "初始放置",
+                GameFlowState.Playing => "進行中",
+                GameFlowState.GameOver => "遊戲結束",
+                _ => state.ToString()
+            };
+        }
+
+        if (resultPanel != null)
+            resultPanel.SetActive(state == GameFlowState.GameOver);
+    }
+
+    void HandleTurnChanged(PlayerData player)
+    {
+        if (turnLabel == null)
+            return;
+
+        if (player == null)
+        {
+            turnLabel.text = "等待中...";
+            return;
+        }
+
+        turnLabel.text = $"{player.playerName} ({player.role})";
+    }
+
+    void HandleGameOver(GameResult result)
+    {
+        if (resultLabel == null)
+            return;
+
+        resultLabel.text = result switch
+        {
+            GameResult.Police => "警察陣營獲勝",
+            GameResult.Thieves => "小偷陣營獲勝",
+            _ => "平手"
+        };
+
+        if (resultPanel != null)
+            resultPanel.SetActive(true);
+    }
+
+    void RefreshAll()
+    {
+        if (GameManager.Instance == null)
+            return;
+
+        HandleFlowStateChanged(GameManager.Instance.FlowState);
+        HandleTurnChanged(GameManager.Instance.CurrentTurnPlayer);
+
+        if (roundLabel != null)
+            roundLabel.text = $"第 {GameManager.Instance.CurrentRound} 回合";
+
+        if (GameManager.Instance.Result != GameResult.None)
+            HandleGameOver(GameManager.Instance.Result);
+    }
+
+    void Update()
+    {
+        if (roundLabel != null && GameManager.Instance != null)
+            roundLabel.text = $"第 {GameManager.Instance.CurrentRound} 回合";
+    }
+}

--- a/Assets/Scripts/UI/GameFlowUI.cs.meta
+++ b/Assets/Scripts/UI/GameFlowUI.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f9541744002a49669419f5dc739ea254
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/UI/LobbyUI.cs
+++ b/Assets/Scripts/UI/LobbyUI.cs
@@ -1,0 +1,291 @@
+using System.Text;
+using Unity.Collections;
+using Unity.Netcode;
+using UnityEngine;
+using UnityEngine.UI;
+using TMPro;
+
+public class LobbyUI : MonoBehaviour
+{
+    [Header("Panels")]
+    public GameObject lobbyPanel;
+    public GameObject inGamePanel;
+
+    [Header("Inputs")]
+    public TMP_InputField playerNameInput;
+    public TMP_InputField serverAddressInput;
+    public TMP_InputField maxPlayersInput;
+    public TMP_InputField maxRoundsInput;
+    public TMP_InputField treasureGoalInput;
+
+    [Header("Buttons")]
+    public Button hostButton;
+    public Button joinButton;
+    public Button readyButton;
+    public Button startGameButton;
+    public Button disconnectButton;
+
+    [Header("Labels")]
+    public TMP_Text statusLabel;
+    public TMP_Text playerListLabel;
+
+    private bool isReady;
+
+    void Awake()
+    {
+        if (hostButton != null) hostButton.onClick.AddListener(OnHostClicked);
+        if (joinButton != null) joinButton.onClick.AddListener(OnJoinClicked);
+        if (readyButton != null) readyButton.onClick.AddListener(OnReadyClicked);
+        if (startGameButton != null) startGameButton.onClick.AddListener(OnStartGameClicked);
+        if (disconnectButton != null) disconnectButton.onClick.AddListener(OnDisconnectClicked);
+    }
+
+    void Start()
+    {
+        if (GameManager.Instance != null && GameManager.Instance.useNetworkMode)
+            ShowLobby();
+        else if (GameManager.Instance != null && !GameManager.Instance.useNetworkMode)
+            ShowInGame();
+        else
+            ShowLobby();
+
+        if (playerNameInput != null && string.IsNullOrWhiteSpace(playerNameInput.text))
+            playerNameInput.text = $"Player{Random.Range(1000, 9999)}";
+
+        if (serverAddressInput != null && string.IsNullOrWhiteSpace(serverAddressInput.text))
+            serverAddressInput.text = "127.0.0.1";
+
+        ApplyDefaultConfigToInputs();
+        RefreshUI();
+    }
+
+    void OnEnable()
+    {
+        if (NetworkRoomManager.Instance != null)
+            NetworkRoomManager.Instance.OnLobbyUpdated += RefreshUI;
+
+        if (GameManager.Instance != null)
+            GameManager.Instance.OnFlowStateChanged += HandleFlowStateChanged;
+    }
+
+    void OnDisable()
+    {
+        if (NetworkRoomManager.Instance != null)
+            NetworkRoomManager.Instance.OnLobbyUpdated -= RefreshUI;
+
+        if (GameManager.Instance != null)
+            GameManager.Instance.OnFlowStateChanged -= HandleFlowStateChanged;
+    }
+
+    void Update()
+    {
+        if (NetworkManager.Singleton == null)
+            return;
+
+        if (NetworkManager.Singleton.IsConnectedClient &&
+            !NetworkManager.Singleton.IsHost &&
+            NetworkRoomManager.Instance != null &&
+            NetworkRoomManager.Instance.IsSpawned &&
+            !HasJoinedLobby())
+        {
+            JoinLobbyAsClient();
+        }
+
+        RefreshUI();
+    }
+
+    bool HasJoinedLobby()
+    {
+        if (NetworkRoomManager.Instance == null)
+            return false;
+
+        foreach (var slot in NetworkRoomManager.Instance.GetConnectedPlayers())
+        {
+            if (slot.ClientId == NetworkManager.Singleton.LocalClientId)
+                return true;
+        }
+
+        return false;
+    }
+
+    void JoinLobbyAsClient()
+    {
+        NetworkRoomManager.Instance.JoinRoomServerRpc(GetPlayerName());
+    }
+
+    void OnHostClicked()
+    {
+        PrepareNetworkSession();
+
+        ApplyConfigFromInputs();
+        if (NetworkBootstrap.Instance == null)
+        {
+            var bootstrapObject = new GameObject("NetworkBootstrap");
+            bootstrapObject.AddComponent<NetworkBootstrap>();
+        }
+
+        if (!NetworkBootstrap.Instance.StartHostGame())
+            return;
+
+        if (NetworkRoomManager.Instance != null)
+            NetworkRoomManager.Instance.RegisterLocalHostPlayer(GetPlayerName());
+
+        ShowLobby();
+        RefreshUI();
+    }
+
+    void OnJoinClicked()
+    {
+        PrepareNetworkSession();
+
+        ApplyConfigFromInputs();
+        if (NetworkBootstrap.Instance == null)
+        {
+            var bootstrapObject = new GameObject("NetworkBootstrap");
+            bootstrapObject.AddComponent<NetworkBootstrap>();
+        }
+
+        string address = serverAddressInput != null ? serverAddressInput.text : "127.0.0.1";
+        if (!NetworkBootstrap.Instance.StartClientGame(address))
+            return;
+
+        ShowLobby();
+        RefreshUI();
+    }
+
+    void OnReadyClicked()
+    {
+        isReady = !isReady;
+        if (NetworkRoomManager.Instance != null)
+            NetworkRoomManager.Instance.SetReadyServerRpc(isReady);
+        RefreshUI();
+    }
+
+    void OnStartGameClicked()
+    {
+        if (NetworkRoomManager.Instance != null)
+            NetworkRoomManager.Instance.StartGameServerRpc();
+    }
+
+    void OnDisconnectClicked()
+    {
+        NetworkBootstrap.Instance?.Shutdown();
+        isReady = false;
+        ShowLobby();
+        RefreshUI();
+    }
+
+    void HandleFlowStateChanged(GameFlowState state)
+    {
+        if (state == GameFlowState.Placement || state == GameFlowState.Playing)
+            ShowInGame();
+        else if (state == GameFlowState.Lobby)
+            ShowLobby();
+    }
+
+    void ShowLobby()
+    {
+        if (lobbyPanel != null) lobbyPanel.SetActive(true);
+        if (inGamePanel != null) inGamePanel.SetActive(false);
+    }
+
+    void ShowInGame()
+    {
+        if (lobbyPanel != null) lobbyPanel.SetActive(false);
+        if (inGamePanel != null) inGamePanel.SetActive(true);
+    }
+
+    void ApplyDefaultConfigToInputs()
+    {
+        if (RoomManager.Instance == null)
+            return;
+
+        var config = RoomManager.Instance.ActiveConfig;
+        if (maxPlayersInput != null) maxPlayersInput.text = config.maxPlayers.ToString();
+        if (maxRoundsInput != null) maxRoundsInput.text = config.maxRounds.ToString();
+        if (treasureGoalInput != null) treasureGoalInput.text = config.treasureGoal.ToString();
+    }
+
+    void ApplyConfigFromInputs()
+    {
+        if (RoomManager.Instance == null)
+            return;
+
+        var config = RoomManager.Instance.ActiveConfig;
+        if (maxPlayersInput != null && int.TryParse(maxPlayersInput.text, out int maxPlayers))
+            config.maxPlayers = Mathf.Clamp(maxPlayers, 2, 12);
+        if (maxRoundsInput != null && int.TryParse(maxRoundsInput.text, out int maxRounds))
+            config.maxRounds = Mathf.Max(1, maxRounds);
+        if (treasureGoalInput != null && int.TryParse(treasureGoalInput.text, out int treasureGoal))
+            config.treasureGoal = Mathf.Max(1, treasureGoal);
+
+        RoomManager.Instance.UpdateConfig(config);
+        if (GameManager.Instance != null)
+            config.ApplyTo(GameManager.Instance);
+    }
+
+    void PrepareNetworkSession()
+    {
+        if (GameManager.Instance != null)
+        {
+            GameManager.Instance.useNetworkMode = true;
+            GameManager.Instance.ResetGameState();
+            GameManager.Instance.SetFlowState(GameFlowState.Lobby);
+        }
+
+        if (MapManager.Instance != null)
+            MapManager.Instance.autoBuildOnStart = false;
+    }
+
+    string GetPlayerName()
+    {
+        if (playerNameInput == null || string.IsNullOrWhiteSpace(playerNameInput.text))
+            return $"Player{Random.Range(1000, 9999)}";
+        return playerNameInput.text.Trim();
+    }
+
+    void RefreshUI()
+    {
+        bool connected = NetworkBootstrap.Instance != null && NetworkBootstrap.Instance.IsConnected;
+        bool isHost = connected && NetworkBootstrap.Instance.IsHost;
+
+        if (hostButton != null) hostButton.interactable = !connected;
+        if (joinButton != null) joinButton.interactable = !connected;
+        if (readyButton != null) readyButton.interactable = connected;
+        if (startGameButton != null) startGameButton.interactable = connected && isHost;
+        if (disconnectButton != null) disconnectButton.interactable = connected;
+
+        if (statusLabel != null)
+        {
+            if (!connected)
+                statusLabel.text = "尚未連線";
+            else if (isHost)
+                statusLabel.text = "已建立房間（Host）";
+            else
+                statusLabel.text = "已加入房間（Client）";
+        }
+
+        if (playerListLabel != null)
+        {
+            var builder = new StringBuilder();
+            if (NetworkRoomManager.Instance != null && connected)
+            {
+                foreach (var slot in NetworkRoomManager.Instance.GetConnectedPlayers())
+                {
+                    builder.AppendLine($"{slot.PlayerName} {(slot.IsReady ? "[Ready]" : "")}");
+                }
+            }
+            else if (RoomManager.Instance != null)
+            {
+                foreach (var player in RoomManager.Instance.LobbyPlayers)
+                {
+                    builder.AppendLine($"{player.playerName} {(player.isReady ? "[Ready]" : "")}");
+                }
+            }
+
+            if (builder.Length == 0)
+                builder.Append("等待玩家加入...");
+            playerListLabel.text = builder.ToString();
+        }
+    }
+}

--- a/Assets/Scripts/UI/LobbyUI.cs.meta
+++ b/Assets/Scripts/UI/LobbyUI.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8367345a426d4b3ba91083705839c35d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/README.md
+++ b/README.md
@@ -4,9 +4,55 @@ This repository contains a small Unity project used to prototype a turn based bo
 
 ## 12 Player Demo
 
-The `GameManager` script now exposes settings that control how many players are created. By default it creates 8 regular police, 2 corrupt police and 2 thief players, totalling **12** participants. Players are distributed across teams automatically.
+The `GameManager` script exposes settings that control how many players are created. By default it creates 8 regular police, 2 corrupt police and 2 thief players, totalling **12** participants. Players are distributed across teams automatically.
 
-To run the demo open the `SampleScene` in Unity and press play. The project uses Unity 2021 or newer.
+To run the local demo open the `SampleScene` in Unity and press play. The project uses Unity 2021 or newer.
 
 An EditMode test named `GameSetupTests` verifies that the `GameManager`
 initializes the full roster of 12 participants. Run it via **Window → General → Test Runner**.
+
+## Network Multiplayer
+
+The project includes a Unity Netcode for GameObjects client/server flow for online play.
+
+### Setup
+
+1. Open `SampleScene`.
+2. Add a UI `Canvas` with the `LobbyUI` component (or wire an existing lobby panel).
+3. Optionally add `GameFlowUI` to display phase, round, and game-over state.
+4. On `GameManager`, enable **Use Network Mode** to skip the local auto-start and wait in the lobby.
+
+`GameSystemsBootstrap` and `RoomManager` are already attached to the `GameManager` prefab.
+
+### Host a game
+
+1. Enter a player name and room settings.
+2. Click **Host** to start a host on port `7777`.
+3. Wait for other players to join.
+4. Click **Start Game** when ready (minimum 2 players).
+
+### Join a game
+
+1. Enter a player name and the host IP address (default `127.0.0.1`).
+2. Click **Join**.
+3. Click **Ready** when prepared to play.
+
+### Game flow
+
+1. **Lobby** – players connect and configure the room.
+2. **Placement** – each player chooses a starting node in turn order.
+3. **Playing** – thieves move first each round, then police teams take turns.
+4. **Game Over** – police win if all thieves are arrested or rounds expire; thieves win if they collect enough treasure.
+
+Only the active player can submit actions. The host/server validates all moves and broadcasts state to every client.
+
+### Scripts
+
+| Script | Purpose |
+|--------|---------|
+| `RoomManager` | Local room configuration and role assignment |
+| `NetworkBootstrap` | Creates `NetworkManager` and starts host/client |
+| `NetworkRoomManager` | Syncs lobby players and starts the networked match |
+| `NetworkGameController` | Server-authoritative placement and action handling |
+| `LobbyUI` | Host/join/ready/start controls |
+| `GameFlowUI` | Phase, turn, and result display |

--- a/README.md
+++ b/README.md
@@ -56,3 +56,51 @@ Only the active player can submit actions. The host/server validates all moves a
 | `NetworkGameController` | Server-authoritative placement and action handling |
 | `LobbyUI` | Host/join/ready/start controls |
 | `GameFlowUI` | Phase, turn, and result display |
+
+## Test Clients
+
+Automated test clients connect to a host, join the lobby, mark ready, and play without manual input. Useful for validating network flow with multiple instances.
+
+### Unity Editor
+
+Use the menu **CorruptPolice → Test Clients**:
+
+- **Launch Test Host** – configures an auto-host that starts the game when enough players join
+- **Launch Test Client** – configures a bot client that connects to `127.0.0.1`
+- **Clear Test Launcher** – removes the launcher object from the scene
+
+Enter Play Mode after choosing a menu item. For multi-client testing, build the game and run multiple executables, or use several Editor/Build instances.
+
+### Command Line (Build)
+
+```bash
+# Test host (auto-starts when 2+ players join)
+./CorruptPolice.exe -testhost -name TestHost -autostart true -minplayers 2
+
+# Test client
+./CorruptPolice.exe -testclient -address 127.0.0.1 -name TestClient_1 -autoready true -autoplay true
+```
+
+Supported flags:
+
+| Flag | Description |
+|------|-------------|
+| `-testhost` / `-testclient` | Run as automated test host or client |
+| `-address` | Server address (clients only, default `127.0.0.1`) |
+| `-name` | Player display name |
+| `-autoready` | Automatically mark ready in lobby (`true`/`false`) |
+| `-autoplay` | Automatically perform placement and turn actions |
+| `-autostart` | Host auto-starts game when enough players join |
+| `-minplayers` | Minimum players before host auto-starts (default `2`) |
+| `-delay` | Seconds between bot actions (default `0.75`) |
+
+### Launch Script
+
+After building the game, run:
+
+```bash
+chmod +x Assets/Scripts/Test/launch_test_clients.sh
+./Assets/Scripts/Test/launch_test_clients.sh /path/to/CorruptPolice.exe 3
+```
+
+This starts one test host and three automated test clients.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

此 PR 完善 CorruptPolice 的完整遊戲流程，並加入 Unity Netcode for GameObjects 的 Host/Client 連線架構，讓多位玩家可透過網路連線遊玩。

## 遊戲流程

新增 `GameFlowState` 狀態機，涵蓋：

- **Lobby** — 等待玩家加入
- **Placement** — 依序選擇起始節點
- **Playing** — 回合制進行（小偷先行，再輪替警察隊伍）
- **GameOver** — 顯示勝負結果

`GameManager` 新增事件（`OnFlowStateChanged`、`OnTurnChanged`、`OnGameOver`）與 `TryExecuteAction`，供本地與伺服器權威邏輯共用。

## 網路連線

| 元件 | 功能 |
|------|------|
| `NetworkBootstrap` | 自動建立 NetworkManager，啟動 Host/Client |
| `NetworkRoomManager` | 同步大廳玩家列表、Ready 狀態、開始遊戲 |
| `NetworkGameController` | 伺服器驗證放置與行動，廣播狀態至所有客戶端 |
| `LobbyUI` | Host / Join / Ready / Start 操作介面 |
| `GameFlowUI` | 顯示階段、回合、勝負 |

## 使用方式

1. 在場景 Canvas 掛上 `LobbyUI`（並連接 UI 元件）
2. 可選：掛上 `GameFlowUI` 顯示回合資訊
3. Host 按「建立房間」（預設 port 7777）
4. 其他玩家輸入主機 IP 後按「加入」
5. Host 在至少 2 名玩家加入後按「開始遊戲」

## 其他變更

- 完善 `RoomManager`：房間設定、角色分配
- `MapManager` 支援 `mapSeed` 同步寶藏位置
- `PlayerInputController` 限制僅當前回合的本地玩家可操作
- 新增 `GameSetupTests` EditMode 測試
- 更新 README 說明

## 測試

- [ ] 本地單機模式（`useNetworkMode = false`）仍可正常遊玩
- [ ] Host 建立房間，Client 加入並 Ready
- [ ] Host 開始遊戲後，Placement 與 Playing 階段同步正常
- [ ] 執行 **Window → General → Test Runner** 中的 `GameSetupTests`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e4a8c070-7be9-4fef-8dd3-2b12bb29274f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e4a8c070-7be9-4fef-8dd3-2b12bb29274f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

